### PR TITLE
safer 'install' task

### DIFF
--- a/xmake/actions/install/main.lua
+++ b/xmake/actions/install/main.lua
@@ -85,15 +85,28 @@ function main()
     -- init finished states
     _g.finished = {}
 
-    -- build it first
-    task.run("build", {target = targetname})
+    task.run("config", {target = targetname})
 
     -- install all?
-    if targetname == "all" then
-        for _, target in pairs(project.targets()) do
-            _install_target_and_deps(target)
-        end
-    else
-        _install_target_and_deps(project.target(targetname))
-    end
+    try{
+        function ()
+            if targetname == "all" then
+                for _, target in pairs(project.targets()) do
+                    _install_target_and_deps(target)
+                end
+            else
+                _install_target_and_deps(project.target(targetname))
+            end
+        end,
+        catch
+        {
+            function (errors)
+                -- print user-friendly notes
+                cprint("${bright red}error: ${default red}installation fail. may it hasn't built before or permission denied")
+                cprint("${bright yellow}note: ${default yellow}try `xmake;sudo xmake install`")
+                cprint("${bright yellow}note: ${default yellow}or `xmake&&xmake install` in cmd on Windows with Administrator permission")
+                raise(errors)
+            end
+        }
+    }
 end

--- a/xmake/actions/install/main.lua
+++ b/xmake/actions/install/main.lua
@@ -85,11 +85,10 @@ function main()
     -- init finished states
     _g.finished = {}
 
-    task.run("config", {target = targetname})
-
-    -- install all?
     try{
         function ()
+            task.run("safe_config", {target = targetname})
+            -- install all?
             if targetname == "all" then
                 for _, target in pairs(project.targets()) do
                     _install_target_and_deps(target)

--- a/xmake/actions/safe_config/main.lua
+++ b/xmake/actions/safe_config/main.lua
@@ -1,0 +1,232 @@
+--!The Make-like Build Utility based on Lua
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- 
+-- Copyright (C) 2015 - 2017, TBOOX Open Source Group.
+--
+-- @author      ruki
+-- @file        main.lua
+--
+
+-- imports
+import("core.base.option")
+import("core.project.config")
+import("core.project.global")
+import("core.project.project")
+import("core.platform.platform")
+import("core.project.cache")
+import("scanner")
+
+-- filter option 
+function _option_filter(name)
+    return name and name ~= "target" and name ~= "file" and name ~= "project" and name ~= "verbose"
+end
+
+-- host changed?
+function _host_changed(targetname)
+    return os.host() ~= config.read("host", targetname)
+end
+
+-- need check
+function _need_check()
+
+    -- clean?
+    if option.get("clean") then
+        return true
+    end
+
+    -- the configure has been changed? reconfig it
+    if config.changed() then
+        return true
+    end
+
+    -- get the current mtimes 
+    local mtimes = project.mtimes()
+
+    -- get the previous mtimes 
+    local changed = false
+    local mtimes_prev = cache.get("mtimes")
+    if mtimes_prev then 
+
+        -- check for all project files
+        for file, mtime in pairs(mtimes) do
+
+            -- modified? reconfig and rebuild it
+            local mtime_prev = mtimes_prev[file]
+            if not mtime_prev or mtime > mtime_prev then
+                changed = true
+                break
+            end
+        end
+    end
+
+    -- update mtimes
+    cache.set("mtimes", mtimes)
+
+    -- changed?
+    return changed
+end
+
+-- check dependent target
+function _check_target_deps(target)
+
+    -- check 
+    for _, depname in ipairs(target:get("deps")) do
+
+        -- check dependent target name
+        assert(depname ~= target:name(), "the target(%s) cannot depend self!", depname)
+
+        -- get dependent target
+        local deptarget = project.target(depname)
+
+        -- check dependent target name
+        assert(deptarget, "unknown target(%s) for %s.deps!", depname, target:name())
+
+        -- check the dependent targets
+        _check_target_deps(deptarget)
+    end
+end
+
+-- check target
+function _check_target(targetname)
+
+    -- check
+    assert(targetname)
+
+    -- all?
+    if targetname == "all" then
+
+        -- check the dependent targets
+        for _, target in pairs(project.targets()) do
+            _check_target_deps(target)
+        end
+    else
+
+        -- get target
+        local target = project.target(targetname)
+
+        -- check target name
+        assert(target, "unknown target: %s", targetname)
+
+        -- check the dependent targets
+        _check_target_deps(target)
+    end
+end
+
+-- main
+function main()
+
+    -- avoid to run this task repeatly
+    if _g.finished then
+        return 
+    end
+
+    -- scan project and generate it if xmake.lua not exists
+    if not os.isfile(project.file()) then
+        scanner.make()
+    end
+
+    -- the target name
+    local targetname = option.get("target") or "all"
+
+    -- load global configure
+    global.load()
+
+    -- init the project configure
+    --
+    -- priority: option > option_cache > global > option_default > config_check > project_check > config_cache
+    --
+    config.init()
+
+    -- enter cache scope
+    cache.enter("local.config")
+
+    -- get the options
+    local options = nil
+    for name, value in pairs(option.options()) do
+        if _option_filter(name) then
+            options = options or {}
+            options[name] = value
+        end
+    end
+
+    -- override configure from the options or cache 
+    if not option.get("clean") then
+        options = options or cache.get("options_" .. targetname)
+    end
+    for name, value in pairs(options) do
+        config.set(name, value)
+    end
+
+    -- merge the global configure 
+    for name, value in pairs(global.options()) do 
+        if config.get(name) == nil then
+            config.set(name, value)
+        end
+    end
+
+    -- merge the default options 
+    for name, value in pairs(option.defaults()) do
+        if _option_filter(name) and config.get(name) == nil then
+            config.set(name, value)
+        end
+    end
+
+    -- merge the checked configure 
+    local recheck = _need_check()
+    if recheck then
+        raise("recheck needed but recheck is avoided in safe_config")
+    end
+
+    -- merge the cached configure
+    if not option.get("clean") and not _host_changed(targetname) then
+        config.load(targetname)
+    end
+
+    -- load platform
+    platform.load(config.plat())
+
+    -- translate the build directory
+    local buildir = config.get("buildir")
+    if buildir and path.is_absolute(buildir) then
+        config.set("buildir", path.relative(buildir, project.directory()))
+    end
+
+    -- load project
+    project.load()
+
+    -- check target
+    _check_target(targetname)
+
+    -- save options and configure for the given target
+    config.save(targetname)
+    cache.set("options_" .. targetname, options)
+
+    -- save options and configure for each targets if be all
+    if targetname == "all" then
+        for _, target in pairs(project.targets()) do
+            config.save(target:name())
+            cache.set("options_" .. target:name(), options)
+        end
+    end
+
+    -- flush cache
+    cache.flush()
+
+    -- finished 
+    _g.finished = true
+end

--- a/xmake/actions/safe_config/scanner.lua
+++ b/xmake/actions/safe_config/scanner.lua
@@ -1,0 +1,1 @@
+../config/scanner.lua

--- a/xmake/actions/safe_config/xmake.lua
+++ b/xmake/actions/safe_config/xmake.lua
@@ -1,0 +1,28 @@
+--!The Make-like Build Utility based on Lua
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- 
+-- Copyright (C) 2015 - 2017, TBOOX Open Source Group.
+--
+-- @author      TitanSnow
+-- @file        xmake.lua
+--
+
+-- define task
+task("safe_config")
+    -- on run
+    on_run("main")


### PR DESCRIPTION
This pull request is trying to fix a problem about *security*

When installing something, users take it for granted to give command higher permission. I think most users use <code>sudo xmake install</code> instead of <code>xmake install</code>, because installing will put files into paths like <code>/usr/local</code> and root permission is required.

That is the problem. I found xmake will always build the target before installing even if it has been built before. And the building is a *latent danger*. For example, a bad man replace the compiler like gcc, and while installing, the fake gcc will get root permission to do something bad.

There are two solutions to avoid this. One is to set permission lower by process self before actual installation. Another is to do *least* things with high permission. My solution is to let task 'install' avoid building and use 'safe_config' which will not reconfig instead of 'config'. When users directly do task 'install' without building before, they will get a note to do building.

Also, except security, the build by root will generate result files with wrong owner. On my computer, after installation, I couldn't even delete 'build' dir without <code>sudo</code>

My solution may be not perfect enough. *Please do not merge easily*. But the secure problem must be fixed.