### PR TITLE
add global makefile intending to replace unsafe install script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
   - cd ..
   - cp -r xmake xmake4build
   - cd xmake4build
-  - sudo ./install
+  - make build; sudo make install
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update --verbose; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install dmd --verbose; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install rust --verbose; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,20 @@ os:
   - linux
   - osx
 
-branches:
-  only:
-    - master
-    - dev
-
 install:
+  - cd ..
+  - cp -r xmake xmake4build
+  - cd xmake4build
   - sudo ./install
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update --verbose; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install dmd --verbose; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew install rust --verbose; fi
 
 script:
-  - xmake create -P ./test 
-  - xmake -P ./test
-  - ./tests/tests
+  - cd ../xmake/core
+  - xmake -v
+  - sudo cp -v build/xmake /usr/local/share/xmake
+  - xmake --version
+  - xmake create test_project
+  - cd test_project
+  - xmake

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,77 @@
+# is debug?
+debug  :=n
+verbose:=
+
+#debug  :=y
+#verbose:=-v
+
+# prefix
+prefix:=$(if $(prefix),$(prefix),$(if $(findstring /usr/local/bin,$(PATH)),/usr/local,/usr))
+
+# platform
+PLAT 		:=$(if $(PLAT),$(PLAT),$(if ${shell uname | egrep -i linux},linux,))
+PLAT 		:=$(if $(PLAT),$(PLAT),$(if ${shell uname | egrep -i darwin},macosx,))
+PLAT 		:=$(if $(PLAT),$(PLAT),$(if ${shell uname | egrep -i cygwin},cygwin,))
+PLAT 		:=$(if $(PLAT),$(PLAT),$(if ${shell uname | egrep -i mingw},mingw,))
+PLAT 		:=$(if $(PLAT),$(PLAT),$(if ${shell uname | egrep -i windows},windows,))
+PLAT 		:=$(if $(PLAT),$(PLAT),linux)
+
+# architecture
+ifeq ($(ARCH),)
+
+ARCH 		:=$(if $(findstring windows,$(PLAT)),x86,$(ARCH))
+ARCH 		:=$(if $(findstring mingw,$(PLAT)),x86,$(ARCH))
+ARCH 		:=$(if $(findstring macosx,$(PLAT)),x$(shell getconf LONG_BIT),$(ARCH))
+ARCH 		:=$(if $(findstring linux,$(PLAT)),x$(shell getconf LONG_BIT),$(ARCH))
+ARCH 		:=$(if $(findstring x32,$(ARCH)),i386,$(ARCH))
+ARCH 		:=$(if $(findstring x64,$(ARCH)),x86_64,$(ARCH))
+ARCH 		:=$(if $(findstring iphoneos,$(PLAT)),armv7,$(ARCH))
+ARCH 		:=$(if $(findstring android,$(PLAT)),armv7,$(ARCH))
+
+endif
+
+xmake_dir_install   :=$(prefix)/share/xmake
+xmake_core          :=./core/bin/demo.pkg/bin/$(PLAT)/$(ARCH)/demo.b
+xmake_core_install  :=$(xmake_dir_install)/xmake
+xmake_loader        :=/tmp/xmake_loader
+xmake_loader_install:=$(prefix)/bin/xmake
+
+tip:
+	@echo '$(MAKE) build; sudo $(MAKE) install'
+
+build:
+	@echo compiling xmake-core ...
+	@if [ -f core/.config.mak ]; then rm core/.config.mak; fi
+	@$(MAKE) -C core --no-print-directory f DEBUG=$(debug)
+	@$(MAKE) -C core --no-print-directory c
+	@$(MAKE) -C core --no-print-directory
+
+install:
+	@echo installing to $(prefix) ...
+	@echo plat: $(PLAT)
+	@echo arch: $(ARCH)
+	@# create the xmake install directory
+	@$(MAKE) -C core --no-print-directory i
+	@if [ -d $(xmake_dir_install) ]; then rm -rf $(xmake_dir_install); fi
+	@if [ ! -d $(xmake_dir_install) ]; then mkdir -p $(xmake_dir_install); fi
+	@# install the xmake core file
+	@cp $(xmake_core) $(xmake_core_install)
+	@chmod 777 $(xmake_core_install)
+	@# install the xmake directory
+	@cp -r xmake/* $(xmake_dir_install)
+	@# make the xmake loader
+	@echo '#!/bin/bash' > $(xmake_loader)
+	@echo 'export XMAKE_PROGRAM_DIR=$(xmake_dir_install)' >> $(xmake_loader)
+	@echo '$(xmake_core_install) $(verbose) "$$@"' >> $(xmake_loader)
+	@# install the xmake loader
+	@if [ ! -d $(prefix)/bin ]; then mkdir -p $(prefix)/bin; fi
+	@mv $(xmake_loader) $(xmake_loader_install)
+	@chmod 777 $(xmake_loader_install)
+	@# tip
+	@$(if $(findstring $(prefix)/bin,$(PATH)),,echo 'please export PATH=$$PATH:$(prefix)/bin')
+	@# remove xmake.out
+	@if [ -f '/tmp/xmake.out' ]; then rm /tmp/xmake.out; fi
+	@# ok
+	@echo ok!
+
+.PHONY: tip build install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,10 +14,6 @@ before_build:
   - cmd: dir C:\xmake
 
 build_script:
-  - cmd: cd tests\console_c
-  - cmd: if %platform%==Win32 xmake f -m debug
-  - cmd: if %platform%==Win64 xmake f -m debug -a x64
-  - cmd: xmake 
-
-test_script:
-  - cmd: xmake --version
+  - cmd: cd core
+  - cmd: if %platform%==Win64 xmake f -a x64
+  - cmd: xmake -v


### PR DESCRIPTION
Danger of binding building and installing together is explained clearly in #61 . The install script seems to take the same risk.
```console
$ sudo ./install
```
So a two-step makefile might be better
```console
$ make build
$ sudo make install
```

This pull also includes new self-build CI yaml file. It seems that you nearly finish #60 's work. @waruqi 