### PR TITLE
add global interface "set_default_target"

### DIFF
--- a/xmake/actions/build/main.lua
+++ b/xmake/actions/build/main.lua
@@ -70,7 +70,7 @@ function main()
         function ()
 
             -- build 
-            builder.build(targetname or "all")
+            builder.build(targetname or project.default_target() or "all")
         
         end,
 

--- a/xmake/actions/build/xmake.lua
+++ b/xmake/actions/build/xmake.lua
@@ -49,7 +49,7 @@ task("build")
                 ,   {'j', "jobs",       "kv", "4",          "Specifies the number of jobs to build simultaneously"          }
                
                 ,   {}
-                ,   {nil, "target",     "v",  "all",        "Build the given target."                                       } 
+                ,   {nil, "target",     "v",  nil,          "Build the given target."                                       }
                 }
             }
 

--- a/xmake/actions/install/main.lua
+++ b/xmake/actions/install/main.lua
@@ -39,7 +39,7 @@ function main()
     task.run("build", {target = targetname})
 
     -- get the target name again
-    targetname = targetname or project.default_target()
+    targetname = targetname or project.default_target() or "all"
 
     -- trace
     print("installing to %s ...", option.get("installdir") or platform.get("installdir"))

--- a/xmake/actions/install/main.lua
+++ b/xmake/actions/install/main.lua
@@ -25,6 +25,7 @@
 -- imports
 import("core.base.option")
 import("core.project.task")
+import("core.project.project")
 import("core.platform.platform")
 import("install")
 
@@ -36,6 +37,9 @@ function main()
 
     -- build it first
     task.run("build", {target = targetname})
+
+    -- get the target name again
+    targetname = targetname or project.default_target()
 
     -- trace
     print("installing to %s ...", option.get("installdir") or platform.get("installdir"))

--- a/xmake/actions/install/xmake.lua
+++ b/xmake/actions/install/xmake.lua
@@ -48,7 +48,7 @@ task("install")
                     {'o', "installdir", "kv", nil,      "Set the install directory."    }
 
                 ,   {}
-                ,   {nil, "target",     "v",  "all",    "Install the given target."     }
+                ,   {nil, "target",     "v",  nil,      "Install the given target."     }
                 }
             }
 

--- a/xmake/actions/package/main.lua
+++ b/xmake/actions/package/main.lua
@@ -198,6 +198,9 @@ function main()
     -- build it first
     task.run("build", {target = targetname})
 
+    -- get the target name again
+    targetname = targetname or project.default_target()
+
     -- init finished states
     _g.finished = {}
 

--- a/xmake/actions/package/main.lua
+++ b/xmake/actions/package/main.lua
@@ -199,7 +199,7 @@ function main()
     task.run("build", {target = targetname})
 
     -- get the target name again
-    targetname = targetname or project.default_target()
+    targetname = targetname or project.default_target() or "all"
 
     -- init finished states
     _g.finished = {}

--- a/xmake/actions/package/xmake.lua
+++ b/xmake/actions/package/xmake.lua
@@ -48,7 +48,7 @@ task("package")
                     {'o', "outputdir",  "kv", nil,          "Set the output directory."                                     }
                 ,   {'a', "archs",      "kv", nil,          "Compile for the given architecture. (deprecated)"              }        
                 ,   {}
-                ,   {nil, "target",     "v",  "all",        "Package a given target"                                        }   
+                ,   {nil, "target",     "v",  nil,          "Package a given target"                                        }
                 }
             } 
 

--- a/xmake/actions/run/main.lua
+++ b/xmake/actions/run/main.lua
@@ -94,6 +94,9 @@ function main()
     -- build it first
     task.run("build", {target = targetname})
 
+    -- get the target name again
+    targetname = targetname or project.default_target()
+
     -- enter project directory
     local olddir = os.cd(project.directory())
 

--- a/xmake/core/project/project.lua
+++ b/xmake/core/project/project.lua
@@ -189,6 +189,7 @@ function project._interpreter()
             "set_project"
         ,   "set_version"
         ,   "set_modes"
+        ,   "set_default_target"
             -- target.set_xxx
         ,   "target.set_kind"
         ,   "target.set_strip"

--- a/xmake/core/sandbox/modules/import/core/project/project.lua
+++ b/xmake/core/sandbox/modules/import/core/project/project.lua
@@ -105,5 +105,10 @@ function sandbox_core_project.modes()
     return project.get("modes")
 end
 
+-- get default target of the project
+function sandbox_core_project.default_target()
+    return project.get("default_target")
+end
+
 -- return module
 return sandbox_core_project


### PR DESCRIPTION
*This pull is a feature adding.*

Sometimes I don't want end-users to build all targets by default. Just like my libBG project, the "bg" target for building library is main, and other targets for building test program is meaningless to end-users. So I think it would be better to add a interface to let people like me choose default target manually.

This "set_default_target" is applied to task "build", "package", "install" and "run". I do not apply it to other task like "uninstall" because it might trouble end-user. (They always like to uninstall everything)

Design is that just do such work to <code>xmake.lua</code> just like <code>set_project</code> is OK:
```lua
set_default_target("bg")
```
Then the default target will be "bg" instead of "all".