### PR TITLE
xmake getter

### DIFF
--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -5,7 +5,7 @@
 
 $ver='v2.1.3'
 Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$pid-xmake-installer.exe"
-$pid-xmake-installer.exe /S /D=C:\xmake
+Start-Process -FilePath "$pid-xmake-installer.exe" -ArgumentList '/S /D=C:\xmake' -Wait
 Remove-Item "$pid-xmake-installer.exe"
 $env:Path+=";C:\xmake"
 [Environment]::SetEnvironmentVariable("Path",$env:Path,[System.EnvironmentVariableTarget]::User)

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -1,0 +1,12 @@
+# xmake getter
+# usage: (in powershell)
+#  Invoke-Webrequest <my location> -OutFile get.ps1
+#  . .\get.ps1
+
+$ver='v2.1.3'
+Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$pid-xmake-installer.exe"
+$pid-xmake-installer.exe /S /D=C:\xmake
+Remove-Item "$pid-xmake-installer.exe"
+$env:Path+=";C:\xmake"
+[Environment]::SetEnvironmentVariable("Path",$env:Path,[System.EnvironmentVariableTarget]::User)
+xmake --version

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# xmake getter
+# usage: bash <(curl -s <my location>) [branch]
+
+branch=
+if [ x != x$1 ];then branch="-b $1";fi
+git clone --depth=1 $branch https://github.com/tboox/xmake.git /tmp/$$xmake_getter || exit $?
+make -C /tmp/$$xmake_getter --no-print-directory build || exit $?
+if [ 0 -eq $(id -u) ]
+then
+    make -C /tmp/$$xmake_getter --no-print-directory install || exit $?
+else
+    sudo make -C /tmp/$$xmake_getter --no-print-directory install || exit $?
+fi
+rm -rf /tmp/$$xmake_getter
+xmake --version
+exit $?


### PR DESCRIPTION
Please see [docs.codecov.io/docs/about-the-codecov-bash-uploader](https://docs.codecov.io/docs/about-the-codecov-bash-uploader). Codecov simply uses *one command* to upload coverage data:

```bash
bash <(curl -s https://codecov.io/bash)
```

So I'm wondering if it would be better to add a *oneline xmake getter*. I know up to now we could use ubuntu ppa or brew to simply install xmake, *but they're not newest version from head of branch*. For developing xmake and new feature testing, it's meaningful to add this especially using it on CIs.

I have written `get.sh` & `get.ps1` to do so. *After merging*, one could simply use this:

```bash
bash <(curl -s https://raw.githubusercontent.com/tboox/xmake/master/scripts/get.sh)
```

or

```powershell
Invoke-Webrequest 'https://raw.githubusercontent.com/tboox/xmake/master/scripts/get.ps1' -OutFile get.ps1
. .\get.ps1
```

(the powershell version does not fetch the newest snapshot because I'm afraid the popularity of git on Windows)