### PR TITLE
xmake getter improved

### DIFF
--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -44,7 +44,7 @@ try{
     writeErrorTip 'Please set environment var "TMP" to another path'
     myExit 1
 }
-$ver='v2.1.3'
+if($ver -eq $null){ $ver='v2.1.3' }
 Write-Host 'Start downloading... Hope amazon S3 is not broken again'
 try{
     Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$outfile"
@@ -75,7 +75,7 @@ try{
     writeErrorTip 'But xmake could not run... Why?'
     myExit 1
 }
-$branch='master'
+if($branch -eq $null){ $branch='master' }
 Write-Host "Pulling xmake from branch $branch"
 $outfile=$temppath+"\$pid-xmake-repo.zip"
 try{

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -7,5 +7,5 @@ Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$
 Start-Process -FilePath "$pid-xmake-installer.exe" -ArgumentList '/S /D=C:\xmake' -Wait
 Remove-Item "$pid-xmake-installer.exe"
 $env:Path+=";C:\xmake"
-[Environment]::SetEnvironmentVariable("Path",$env:Path,[System.EnvironmentVariableTarget]::User)
+[Environment]::SetEnvironmentVariable("Path",[Environment]::GetEnvironmentVariable("Path",[System.EnvironmentVariableTarget]::User)+";C:\xmake",[System.EnvironmentVariableTarget]::User)
 xmake --version

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -2,6 +2,8 @@
 # usage: (in powershell)
 #  Invoke-Expression (Invoke-Webrequest <my location> -UseBasicParsing).Content
 
+& {
+
 $temppath=($env:TMP,$env:TEMP,'.' -ne $null)[0]
 $outfile=$temppath+"\$pid-xmake-installer.exe"
 try{
@@ -74,4 +76,6 @@ try{
     Set-Location "$oldpwd" -ErrorAction SilentlyContinue
     Remove-Item "$outfile" -ErrorAction SilentlyContinue
     Remove-Item "$repodir" -Recurse -Force -ErrorAction SilentlyContinue
+}
+
 }

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -12,8 +12,12 @@ Function myExit($code){
     }
 }
 
+Function writeErrorTip($msg){
+    Write-Host $msg -BackgroundColor Red -ForegroundColor White
+}
+
 if($PSVersionTable.PSVersion.Major -lt 5){
-    Write-Host 'Sorry but PowerShell v5+ is required'
+    writeErrorTip 'Sorry but PowerShell v5+ is required'
     throw 'PowerShell''s version too low'
 }
 $temppath=($env:TMP,$env:TEMP,'.' -ne $null)[0]
@@ -22,8 +26,8 @@ try{
     Write-Output "$pid"|Out-File -FilePath "$outfile"
     Remove-Item "$outfile"
 }catch{
-    Write-Host 'Cannot write to temp path'
-    Write-Host 'Please set environment var "TMP" to another path'
+    writeErrorTip 'Cannot write to temp path'
+    writeErrorTip 'Please set environment var "TMP" to another path'
     myExit 1
 }
 $ver='v2.1.3'
@@ -31,8 +35,8 @@ Write-Host 'Start downloading... Hope amazon S3 is not broken again'
 try{
     Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$outfile"
 }catch{
-    Write-Host 'Download failed!'
-    Write-Host 'Check your network or... the news of S3 break'
+    writeErrorTip 'Download failed!'
+    writeErrorTip 'Check your network or... the news of S3 break'
     myExit 1
 }
 Write-Host 'Start installation... Hope your antivirus doesn''t trouble'
@@ -42,8 +46,8 @@ try{
     Start-Process -FilePath "$outfile" -ArgumentList "/S /D=$installdir" -Wait
 }catch{
     Remove-Item "$outfile"
-    Write-Host 'Install failed!'
-    Write-Host 'Close your antivirus then try again'
+    writeErrorTip 'Install failed!'
+    writeErrorTip 'Close your antivirus then try again'
     myExit 1
 }
 Remove-Item "$outfile"
@@ -53,8 +57,8 @@ $env:Path+=";$installdir"
 try{
     xmake --version
 }catch{
-    Write-Host 'Everything is showing installation has finished'
-    Write-Host 'But xmake could not run... Why?'
+    writeErrorTip 'Everything is showing installation has finished'
+    writeErrorTip 'But xmake could not run... Why?'
     myExit 1
 }
 $branch='master'
@@ -63,8 +67,8 @@ $outfile=$temppath+"\$pid-xmake-repo.zip"
 try{
     Invoke-Webrequest "https://github.com/tboox/xmake/archive/$branch.zip" -OutFile "$outfile"
 }catch{
-    Write-Host 'Pull Failed!'
-    Write-Host 'xmake is now available but may not be newest'
+    writeErrorTip 'Pull Failed!'
+    writeErrorTip 'xmake is now available but may not be newest'
     myExit
 }
 Write-Host 'Expanding archive...'
@@ -82,8 +86,8 @@ try{
     Copy-Item * "$installdir" -Recurse -Force
     xmake --version
 }catch{
-    Write-Host 'Update Failed!'
-    Write-Host 'xmake is now available but may not be newest'
+    writeErrorTip 'Update Failed!'
+    writeErrorTip 'xmake is now available but may not be newest'
 }finally{
     Set-Location "$oldpwd" -ErrorAction SilentlyContinue
     Remove-Item "$outfile" -ErrorAction SilentlyContinue

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -16,6 +16,20 @@ Function writeErrorTip($msg){
     Write-Host $msg -BackgroundColor Red -ForegroundColor White
 }
 
+Function writeLogoLine($msg){
+    Write-Host $msg -BackgroundColor White -ForegroundColor DarkBlue
+}
+
+writeLogoLine '                  _               '
+writeLogoLine '                 | | _            '
+writeLogoLine '__  ___    ______| |/ /___        '
+writeLogoLine '\ \/ | \  / / _  | / / __ \       '
+writeLogoLine ' \  /|  \/ / / | |  |   __/       '
+writeLogoLine ' /  \| \__/\ \_| \ \ \ \__.       '
+writeLogoLine '/_/\_|_|  |_\___\_\|\_\__/  getter'
+writeLogoLine '                                  '
+writeLogoLine ''
+
 if($PSVersionTable.PSVersion.Major -lt 5){
     writeErrorTip 'Sorry but PowerShell v5+ is required'
     throw 'PowerShell''s version too low'

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -3,8 +3,8 @@
 #  Invoke-Expression (Invoke-Webrequest <my location> -UseBasicParsing).Content
 
 $ver='v2.1.3'
-Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$pid-xmake-installer.exe"
-Start-Process -FilePath "$pid-xmake-installer.exe" -ArgumentList '/S /D=C:\xmake' -Wait
+Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$pid-xmake-installer.exe" -ErrorAction Stop
+Start-Process -FilePath "$pid-xmake-installer.exe" -ArgumentList '/S /D=C:\xmake' -Wait -ErrorAction Stop
 Remove-Item "$pid-xmake-installer.exe"
 $env:Path+=";C:\xmake"
 [Environment]::SetEnvironmentVariable("Path",[Environment]::GetEnvironmentVariable("Path",[System.EnvironmentVariableTarget]::User)+";C:\xmake",[System.EnvironmentVariableTarget]::User)

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -2,7 +2,7 @@
 # usage: (in powershell)
 #  Invoke-Expression (Invoke-Webrequest <my location> -UseBasicParsing).Content
 
-$outfile=($env:TEMP,$env:TMP,'.' -ne $null)[0]+"\$pid-xmake-installer.exe"
+$outfile=($env:TMP,$env:TEMP,'.' -ne $null)[0]+"\$pid-xmake-installer.exe"
 $ver='v2.1.3'
 Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$outfile" -ErrorAction Stop
 Start-Process -FilePath "$outfile" -ArgumentList '/S /D=C:\xmake' -Wait -ErrorAction Stop

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -12,6 +12,10 @@ Function myExit($code){
     }
 }
 
+if($PSVersionTable.PSVersion.Major -lt 5){
+    Write-Host 'Sorry but PowerShell v5+ is required'
+    throw 'PowerShell''s version too low'
+}
 $temppath=($env:TMP,$env:TEMP,'.' -ne $null)[0]
 $outfile=$temppath+"\$pid-xmake-installer.exe"
 try{

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -4,8 +4,8 @@
 
 $outfile=($env:TMP,$env:TEMP,'.' -ne $null)[0]+"\$pid-xmake-installer.exe"
 $ver='v2.1.3'
-Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$outfile" -ErrorAction Stop
-Start-Process -FilePath "$outfile" -ArgumentList '/S /D=C:\xmake' -Wait -ErrorAction Stop
+Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$outfile"
+Start-Process -FilePath "$outfile" -ArgumentList '/S /D=C:\xmake' -Wait
 Remove-Item "$outfile"
 $env:Path+=";C:\xmake"
 [Environment]::SetEnvironmentVariable("Path",[Environment]::GetEnvironmentVariable("Path",[System.EnvironmentVariableTarget]::User)+";C:\xmake",[System.EnvironmentVariableTarget]::User)

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -1,7 +1,6 @@
 # xmake getter
 # usage: (in powershell)
-#  Invoke-Webrequest <my location> -OutFile get.ps1
-#  . .\get.ps1
+#  Invoke-Expression (Invoke-Webrequest <my location> -UseBasicParsing).Content
 
 $ver='v2.1.3'
 Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$pid-xmake-installer.exe"

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -2,10 +2,11 @@
 # usage: (in powershell)
 #  Invoke-Expression (Invoke-Webrequest <my location> -UseBasicParsing).Content
 
+$outfile=($env:TEMP,$env:TMP,'.' -ne $null)[0]+"\$pid-xmake-installer.exe"
 $ver='v2.1.3'
-Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$pid-xmake-installer.exe" -ErrorAction Stop
-Start-Process -FilePath "$pid-xmake-installer.exe" -ArgumentList '/S /D=C:\xmake' -Wait -ErrorAction Stop
-Remove-Item "$pid-xmake-installer.exe"
+Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$outfile" -ErrorAction Stop
+Start-Process -FilePath "$outfile" -ArgumentList '/S /D=C:\xmake' -Wait -ErrorAction Stop
+Remove-Item "$outfile"
 $env:Path+=";C:\xmake"
 [Environment]::SetEnvironmentVariable("Path",[Environment]::GetEnvironmentVariable("Path",[System.EnvironmentVariableTarget]::User)+";C:\xmake",[System.EnvironmentVariableTarget]::User)
 xmake --version

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -4,6 +4,14 @@
 
 & {
 
+Function myExit($code){
+    if($code -is [int] -and $code -ne 0){
+        throw $Error[0]
+    }else{
+        break
+    }
+}
+
 $temppath=($env:TMP,$env:TEMP,'.' -ne $null)[0]
 $outfile=$temppath+"\$pid-xmake-installer.exe"
 try{
@@ -12,7 +20,7 @@ try{
 }catch{
     Write-Host 'Cannot write to temp path'
     Write-Host 'Please set environment var "TMP" to another path'
-    Exit 1
+    myExit 1
 }
 $ver='v2.1.3'
 Write-Host 'Start downloading... Hope amazon S3 is not broken again'
@@ -21,7 +29,7 @@ try{
 }catch{
     Write-Host 'Download failed!'
     Write-Host 'Check your network or... the news of S3 break'
-    Exit 1
+    myExit 1
 }
 Write-Host 'Start installation... Hope your antivirus doesn''t trouble'
 $installdir=$HOME+'\xmake'
@@ -32,7 +40,7 @@ try{
     Remove-Item "$outfile"
     Write-Host 'Install failed!'
     Write-Host 'Close your antivirus then try again'
-    Exit 1
+    myExit 1
 }
 Remove-Item "$outfile"
 Write-Host 'Adding to PATH... almost done'
@@ -43,7 +51,7 @@ try{
 }catch{
     Write-Host 'Everything is showing installation has finished'
     Write-Host 'But xmake could not run... Why?'
-    Exit 1
+    myExit 1
 }
 $branch='master'
 Write-Host "Pulling xmake from branch $branch"
@@ -53,7 +61,7 @@ try{
 }catch{
     Write-Host 'Pull Failed!'
     Write-Host 'xmake is now available but may not be newest'
-    Exit
+    myExit
 }
 Write-Host 'Expanding archive...'
 New-Item -Path "$temppath" -Name "$pid-xmake-repo" -ItemType "directory" -Force

--- a/scripts/get.ps1
+++ b/scripts/get.ps1
@@ -3,10 +3,36 @@
 #  Invoke-Expression (Invoke-Webrequest <my location> -UseBasicParsing).Content
 
 $outfile=($env:TMP,$env:TEMP,'.' -ne $null)[0]+"\$pid-xmake-installer.exe"
+try{
+    Write-Output "$pid"|Out-File -FilePath "$outfile"
+    Remove-Item "$outfile"
+}catch{
+    Write-Host 'Cannot write to temp path'
+    Write-Host 'Please set environment var "TMP" to another path'
+    Exit 1
+}
 $ver='v2.1.3'
-Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$outfile"
-Start-Process -FilePath "$outfile" -ArgumentList '/S /D=C:\xmake' -Wait
+Write-Host 'Start downloading... Hope amazon S3 is not broken again'
+try{
+    Invoke-Webrequest "https://github.com/tboox/xmake/releases/download/$ver/xmake-$ver.exe" -OutFile "$outfile"
+}catch{
+    Write-Host 'Download failed!'
+    Write-Host 'Check your network or... the news of S3 break'
+    Exit 1
+}
+Write-Host 'Start installation... Hope your antivirus doesn''t trouble'
+$installdir=$HOME+'\xmake'
+Write-Host "Install to $installdir"
+try{
+    Start-Process -FilePath "$outfile" -ArgumentList "/S /D=$installdir" -Wait
+}catch{
+    Remove-Item "$outfile"
+    Write-Host 'Install failed!'
+    Write-Host 'Close your antivirus then try again'
+    Exit 1
+}
 Remove-Item "$outfile"
-$env:Path+=";C:\xmake"
-[Environment]::SetEnvironmentVariable("Path",[Environment]::GetEnvironmentVariable("Path",[System.EnvironmentVariableTarget]::User)+";C:\xmake",[System.EnvironmentVariableTarget]::User)
+Write-Host 'Adding to PATH... almost done'
+$env:Path+=";$installdir"
+[Environment]::SetEnvironmentVariable("Path",[Environment]::GetEnvironmentVariable("Path",[System.EnvironmentVariableTarget]::User)+";$installdir",[System.EnvironmentVariableTarget]::User)    # this step is optional because installer writes path to regedit
 xmake --version

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -25,7 +25,7 @@ install_tools()
 {
     { apt-get --version >/dev/null 2>&1 && $sudoprefix apt-get install -y git build-essential; } ||
     { yum --version >/dev/null 2>&1 && $sudoprefix yum install -y git && $sudoprefix yum groupinstall -y 'Development Tools'; } ||
-    { zypper --version >/dev/null 2>&1 && $sudoprefix zypper install -n git && $sudoprefix zypper install -n -t pattern devel_C_C++; } ||
+    { zypper --version >/dev/null 2>&1 && $sudoprefix zypper install --non-interactive git && $sudoprefix zypper install --non-interactive -t pattern devel_C_C++; } ||
     { pacman -V >/dev/null 2>&1 && $sudoprefix pacman -S --noconfirm git base-devel; }
 }
 test_tools || { install_tools && test_tools; } ||

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -58,7 +58,11 @@ install_tools()
 }
 test_tools || { install_tools && test_tools; } || my_exit 'Dependencies Installation Fail' 1
 branch=
-if [ x != "x$1" ];then branch="-b $1";fi
+if [ x != "x$1" ]
+then
+    branch="-b $1"
+    echo "Branch: $1"
+fi
 git clone --depth=1 $branch https://github.com/tboox/xmake.git /tmp/$$xmake_getter || my_exit 'Clone Fail'
 make -C /tmp/$$xmake_getter --no-print-directory build || my_exit 'Build Fail'
 IFS=':'

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -33,7 +33,7 @@ test_tools || { install_tools && test_tools; } ||
 {
     rv=$?
     echo 'Dependencies Installation Fail'
-    exit $rv
+    if [ $rv -ne 0 ];then exit $rv;else exit 1;fi
 }
 branch=
 if [ x != x$1 ];then branch="-b $1";fi

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # xmake getter
 # usage: bash <(curl -s <my location>) [branch]
@@ -7,7 +7,26 @@ branch=
 if [ x != x$1 ];then branch="-b $1";fi
 git clone --depth=1 $branch https://github.com/tboox/xmake.git /tmp/$$xmake_getter || exit $?
 make -C /tmp/$$xmake_getter --no-print-directory build || exit $?
-if [ 0 -eq $(id -u) ]
+IFS=':'
+patharr=($PATH)
+prefix=
+for st in ${patharr[@]}
+do
+    if [[ "$st" = "$HOME"* ]]
+    then
+        cwd=$(pwd)
+        mkdir -p "$st"
+        cd "$st"/..
+        mkdir -p share 2>/dev/null || continue
+        prefix=$(pwd)
+        cd "$cwd"
+        break
+    fi
+done
+if [ x$prefix != x ]
+then
+    make -C /tmp/$$xmake_getter --no-print-directory install prefix="$prefix"|| exit $?
+elif [ 0 -eq $(id -u) ]
 then
     make -C /tmp/$$xmake_getter --no-print-directory install || exit $?
 else
@@ -15,4 +34,3 @@ else
 fi
 rm -rf /tmp/$$xmake_getter
 xmake --version
-exit $?

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -4,14 +4,16 @@
 # usage: bash <(curl -s <my location>) [branch]
 
 # print a LOGO!
-echo '                  _'
-echo '                 | | _'
-echo '__  ___    ______| |/ /___'
-echo '\ \/ | \  / / _  | / / __ \'
-echo ' \  /|  \/ / / | |  |   __/'
-echo ' /  \| \__/\ \_| \ \ \ \__.'
+echo -ne '\x1b[07m'
+echo '                  _               '
+echo '                 | | _            '
+echo '__  ___    ______| |/ /___        '
+echo '\ \/ | \  / / _  | / / __ \       '
+echo ' \  /|  \/ / / | |  |   __/       '
+echo ' /  \| \__/\ \_| \ \ \ \__.       '
 echo '/_/\_|_|  |_\___\_\|\_\__/  getter'
-echo -e '\n'
+echo '                                  '
+echo -e '\x1b[0m'
 
 brew --version >/dev/null 2>&1 && brew install --HEAD xmake && xmake --version && exit
 if [ 0 -ne $(id -u) ]
@@ -22,7 +24,12 @@ else
 fi
 my_exit(){
     rv=$?
-    if [ "x$1" != x ];then echo "$1";fi
+    if [ "x$1" != x ]
+    then
+        echo -ne '\x1b[41;37m'
+        echo "$1"
+        echo -ne '\x1b[0m'
+    fi
     rm -rf /tmp/$$xmake_getter 2>/dev/null
     if [ "x$2" != x ]
     then

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -24,7 +24,7 @@ test_tools()
 install_tools()
 {
     { apt-get --version >/dev/null 2>&1 && $sudoprefix apt-get install -y git build-essential; } ||
-    { yum --version >/dev/null 2>&1 && $sudoprefix yum install -y git 'Development Tools'; } ||
+    { yum --version >/dev/null 2>&1 && $sudoprefix yum install -y git && $sudoprefix yum groupinstall -y 'Development Tools'; } ||
     { zypper --version >/dev/null 2>&1 && $sudoprefix zypper install -n git && $sudoprefix zypper install -n -t pattern devel_C_C++; } ||
     { pacman -V >/dev/null 2>&1 && $sudoprefix pacman -S --noconfirm git base-devel; }
 }

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -48,7 +48,10 @@ do
     then
         cwd=$(pwd)
         mkdir -p "$st"
-        cd "$st"/..
+        cd "$st"
+        echo $$ > $$xmake_getter_test 2>/dev/null || continue
+        rm $$xmake_getter_test 2>/dev/null || continue
+        cd ..
         mkdir -p share 2>/dev/null || continue
         prefix=$(pwd)
         cd "$cwd"

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -3,6 +3,7 @@
 # xmake getter
 # usage: bash <(curl -s <my location>) [branch]
 
+brew --version >/dev/null 2>&1 && brew install --HEAD xmake && xmake --version && exit
 if [ 0 -ne $(id -u) ]
 then
     sudoprefix=sudo

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -3,6 +3,16 @@
 # xmake getter
 # usage: bash <(curl -s <my location>) [branch]
 
+# print a LOGO!
+echo '                  _'
+echo '                 | | _'
+echo '__  ___    ______| |/ /___'
+echo '\ \/ | \  / / _  | / / __ \'
+echo ' \  /|  \/ / / | |  |   __/'
+echo ' /  \| \__/\ \_| \ \ \ \__.'
+echo '/_/\_|_|  |_\___\_\|\_\__/  getter'
+echo -e '\n'
+
 brew --version >/dev/null 2>&1 && brew install --HEAD xmake && xmake --version && exit
 if [ 0 -ne $(id -u) ]
 then

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -25,7 +25,7 @@ install_tools()
 {
     { apt-get --version >/dev/null 2>&1 && $sudoprefix apt-get install -y git build-essential; } ||
     { yum --version >/dev/null 2>&1 && $sudoprefix yum install -y git && $sudoprefix yum groupinstall -y 'Development Tools'; } ||
-    { zypper --version >/dev/null 2>&1 && $sudoprefix zypper install --non-interactive git && $sudoprefix zypper install --non-interactive -t pattern devel_C_C++; } ||
+    { zypper --version >/dev/null 2>&1 && $sudoprefix zypper --non-interactive install git && $sudoprefix zypper --non-interactive install -t pattern devel_C_C++; } ||
     { pacman -V >/dev/null 2>&1 && $sudoprefix pacman -S --noconfirm git base-devel; }
 }
 test_tools || { install_tools && test_tools; } ||

--- a/scripts/get.sh
+++ b/scripts/get.sh
@@ -63,7 +63,12 @@ then
     branch="-b $1"
     echo "Branch: $1"
 fi
-git clone --depth=1 $branch https://github.com/tboox/xmake.git /tmp/$$xmake_getter || my_exit 'Clone Fail'
+if [ 'x-b __local__' != "x$branch" ]
+then
+    git clone --depth=1 $branch https://github.com/tboox/xmake.git /tmp/$$xmake_getter || my_exit 'Clone Fail'
+else
+    cp -r "$(git rev-parse --show-toplevel 2>/dev/null || hg root 2>/dev/null || echo $PWD)" /tmp/$$xmake_getter || my_exit 'Clone Fail'
+fi
 make -C /tmp/$$xmake_getter --no-print-directory build || my_exit 'Build Fail'
 IFS=':'
 patharr=($PATH)


### PR DESCRIPTION
:white_check_mark: supported

:x: not supported

:heavy_minus_sign: partial supported

* `get.sh`
  * package manager :package: (platform) tested by docker :whale: 
    * :white_check_mark: apt-get
        * :white_check_mark: ubuntu
        * :white_check_mark: debian
    * :white_check_mark: yum
        * :white_check_mark: centos
        * :white_check_mark: fedora
    * :white_check_mark: zypper
        * :white_check_mark: opensuse
    * :white_check_mark: pacman
        * :white_check_mark: archlinux
    * :white_check_mark: homebrew
        * :white_check_mark: homebrew
        * :white_check_mark: linuxbrew
    * :x: macports
    * :x: portage
  * features :flags: 
    * :white_check_mark: get newest :octocat: with branch specified
    * :white_check_mark: build tool check & install :chains: 
    * :white_check_mark: auto build :building_construction: 
    * :white_check_mark: path detection :house: 
    * :white_check_mark: error log with color :rainbow: 
    * :heavy_minus_sign: no root requirement (partial) :family_man_woman_girl: 
    * :white_check_mark: local git repo install :hammer: 
    * :white_check_mark: cleanup :feet:
* `get.ps1`
  * platform :factory: 
    * :white_check_mark: Windows 10
    * :white_check_mark: Windows Server 2016
    * :heavy_minus_sign: Windows 8 (update powershell)
    * :heavy_minus_sign: Windows 7 (update powershell)
    * :x: Windows XP
  * features :flags: 
    * :white_check_mark: get newest :octocat: with branch specified
    * :x: build tool check & install :chains: 
    * :white_check_mark: auto build :building_construction: 
    * :white_check_mark: path detection :house: 
    * :white_check_mark: error log with color :rainbow: 
    * :white_check_mark: no administrator requirement :family_man_woman_girl: 
    * :x: local git repo install :hammer: 
    * :white_check_mark: cleanup :feet: