### PR TITLE
fix sandbox_utils.cprint no color reset eol

### DIFF
--- a/xmake/core/sandbox/modules/utils.lua
+++ b/xmake/core/sandbox/modules/utils.lua
@@ -100,7 +100,7 @@ end
 function sandbox_utils.cprint(format, ...)
 
     -- done
-    utils._iowrite(colors(vformat(format, ...) .. "\n"))
+    utils._iowrite(colors(vformat(format, ...)) .. "\n")
 end
 
 -- print format string, the builtin variables and colors without newline


### PR DESCRIPTION
```console
$ xmake create -P test
$ cd test
$ xmake
$ xmake run
[100%]: linking.release hw
hello world!    # This line is magenta! Last line's color is not reset!
```

The bug is that sandbox_utils.cprint does not reset color at end of line