### PR TITLE
soft-wrap `help`

### DIFF
--- a/core/src/xmake/machine.c
+++ b/core/src/xmake/machine.c
@@ -79,6 +79,7 @@ tb_int_t xm_os_setenv(lua_State* lua);
 tb_int_t xm_os_getenv(lua_State* lua);
 tb_int_t xm_os_emptydir(lua_State* lua);
 tb_int_t xm_os_strerror(lua_State* lua);
+tb_int_t xm_os_getwinsize(lua_State* lua);
 
 // the path functions
 tb_int_t xm_path_relative(lua_State* lua);
@@ -126,6 +127,7 @@ static luaL_Reg const g_os_functions[] =
 ,   { "getenv",         xm_os_getenv    }
 ,   { "emptydir",       xm_os_emptydir  }
 ,   { "strerror",       xm_os_strerror  }
+,   { "getwinsize",     xm_os_getwinsize}
 ,   { tb_null,          tb_null         }
 };
 

--- a/core/src/xmake/makefile
+++ b/core/src/xmake/makefile
@@ -35,6 +35,7 @@ xmake_C_FILES 			+= \
 						os/getenv \
 						os/emptydir \
 						os/strerror \
+						os/getwinsize \
 						path/relative \
 						path/absolute \
 						path/translate \

--- a/core/src/xmake/os/getwinsize.c
+++ b/core/src/xmake/os/getwinsize.c
@@ -1,0 +1,72 @@
+/*!The Make-like Build Utility based on Lua
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015 - 2017, TBOOX Open Source Group.
+ *
+ * @author      TitanSnow
+ * @file        getwinsize.c
+ *
+ */
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * trace
+ */
+#define TB_TRACE_MODULE_NAME                "getwinsize"
+#define TB_TRACE_MODULE_DEBUG               (0)
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * includes
+ */
+#include "prefix.h"
+#ifdef TB_CONFIG_OS_LINUX
+#include <sys/ioctl.h>
+#include <termios.h>
+#include <unistd.h>
+#endif
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * implementation
+ */
+tb_int_t xm_os_getwinsize(lua_State* lua)
+{
+    // check
+    tb_assert_and_check_return_val(lua, 0);
+
+    // def w&h
+    unsigned short w=80, h=40;
+
+    // get winsize
+#   ifdef TB_CONFIG_OS_LINUX
+    struct winsize size;
+    ioctl(STDOUT_FILENO, TIOCGWINSZ, &size);
+    w=size.ws_col;
+    h=size.ws_row;
+#   endif
+
+    // done os.getwinsize()
+    lua_newtable(lua);
+    lua_pushstring(lua, "width");
+    lua_pushinteger(lua, w);
+    lua_settable(lua, -3);
+    lua_pushstring(lua, "height");
+    lua_pushinteger(lua, h);
+    lua_settable(lua, -3);
+
+    // ok
+    return 1;
+}

--- a/xmake/core/base/option.lua
+++ b/xmake/core/base/option.lua
@@ -1046,13 +1046,13 @@ function option.show_options(options)
         -- append color
         option_info = "${green}" .. option_info .. "${clear}"
 
+        function get_linelen(st)
+            local poss = string.find(string.reverse(st), "\n")
+            if not poss then return (#st) end
+            local start_pos, _ = poss
+            return start_pos - 1
+        end
         function inwidth_append(dst, st, padding, width, remain_width)
-            function get_linelen(st)
-                local poss = string.find(string.reverse(st), "\n")
-                if not poss then return (#st) end
-                local start_pos, _ = poss
-                return start_pos - 1
-            end
             function get_lastspace(st)
                 local poss = string.find(string.reverse(st), "[%s-]")
                 if not poss then return (#st) end
@@ -1090,7 +1090,13 @@ function option.show_options(options)
         -- append the default value
         local default = opt[4]
         if default then
-            option_info = inwidth_append(option_info, " (default: ${bright}" .. tostring(default) .. "${clear})", padding + 1, console_width)    -- wrong, but looks ok
+            option_info = inwidth_append(option_info, " (default: ", padding + 1, console_width)
+            local origin_width = get_linelen(option_info)
+            option_info = option_info .. "${bright}"
+            option_info = inwidth_append(option_info, tostring(default), padding + 1, console_width, console_width - origin_width)
+            origin_width = option._ifelse(origin_width + (#(tostring(default))) > console_width, get_linelen(option_info), origin_width + (#(tostring(default))))
+            option_info = option_info .. "${clear}"
+            option_info = inwidth_append(option_info, ")", padding + 1, console_width, console_width - origin_width)
         end
 
         -- print option info

--- a/xmake/core/base/option.lua
+++ b/xmake/core/base/option.lua
@@ -1046,16 +1046,51 @@ function option.show_options(options)
         -- append color
         option_info = "${green}" .. option_info .. "${clear}"
 
+        function inwidth_append(dst, st, padding, width, remain_width)
+            function get_linelen(st)
+                local poss = string.find(string.reverse(st), "\n")
+                if not poss then return (#st) end
+                local start_pos, _ = poss
+                return start_pos - 1
+            end
+            function get_lastspace(st)
+                local poss = string.find(string.reverse(st), "[%s-]")
+                if not poss then return (#st) end
+                local start_pos, _ = poss
+                return (#st) - start_pos + 1
+            end
+            if padding >= width then
+                return dst .. st
+            end
+            local white_padding = string.rep(" ", padding)
+            if remain_width == nil then remain_width = width - get_linelen(dst) end    -- because of colored string, it's wrong sometimes
+            if remain_width <= 0 then
+                return inwidth_append(dst .. "\n" .. white_padding, st, padding, width, width - padding)
+            end
+            if (#st) <= remain_width then
+                return dst .. st
+            end
+            local lastspace = get_lastspace(string.sub(st, 1, remain_width))
+            if lastspace + 1 > (#st) then
+                return dst .. st
+            else
+                return inwidth_append(dst .. string.sub(st, 1, lastspace) .. "\n" .. white_padding, string.ltrim(string.sub(st, lastspace + 1)), padding, width, width - padding)
+            end
+        end
+
+        -- get width of console
+        local console_width = os.getwinsize()["width"]
+
         -- append the option description
         local description = opt[5]
         if description then
-            option_info = option_info .. description
+            option_info = inwidth_append(option_info, description, padding + 1, console_width, console_width - padding - 1)
         end
 
         -- append the default value
         local default = opt[4]
         if default then
-            option_info = option_info .. " (default: ${bright}" .. tostring(default) .. "${clear})"
+            option_info = inwidth_append(option_info, " (default: ${bright}" .. tostring(default) .. "${clear})", padding + 1, console_width)    -- wrong, but looks ok
         end
 
         -- print option info
@@ -1083,7 +1118,7 @@ function option.show_options(options)
                 end
 
                 -- print this description
-                print(spaces .. description)
+                print(inwidth_append(spaces, description, padding + 1, console_width))
 
             -- the description is table?
             elseif type(description) == "table" then
@@ -1098,7 +1133,7 @@ function option.show_options(options)
                     end
 
                     -- print this description
-                    print(spaces .. v)
+                    print(inwidth_append(spaces, v, padding + 1, console_width))
                 end
             end
         end

--- a/xmake/core/base/option.lua
+++ b/xmake/core/base/option.lua
@@ -874,6 +874,38 @@ function option.show_menu(task)
     end
 end  
 
+function get_linelen(st)
+    local poss = string.find(string.reverse(st), "\n")
+    if not poss then return (#st) end
+    local start_pos, _ = poss
+    return start_pos - 1
+end
+function inwidth_append(dst, st, padding, width, remain_width)
+    function get_lastspace(st)
+        local poss = string.find(string.reverse(st), "[%s-]")
+        if not poss then return (#st) end
+        local start_pos, _ = poss
+        return (#st) - start_pos + 1
+    end
+    if padding >= width then
+        return dst .. st
+    end
+    local white_padding = string.rep(" ", padding)
+    if remain_width == nil then remain_width = width - get_linelen(dst) end    -- because of colored string, it's wrong sometimes
+    if remain_width <= 0 then
+        return inwidth_append(dst .. "\n" .. white_padding, st, padding, width, width - padding)
+    end
+    if (#st) <= remain_width then
+        return dst .. st
+    end
+    local lastspace = get_lastspace(string.sub(st, 1, remain_width))
+    if lastspace + 1 > (#st) then
+        return dst .. st
+    else
+        return inwidth_append(dst .. string.sub(st, 1, lastspace) .. "\n" .. white_padding, string.ltrim(string.sub(st, lastspace + 1)), padding, width, width - padding)
+    end
+end
+
 -- show the main menu
 function option.show_main()
 
@@ -953,6 +985,9 @@ function option.show_main()
             -- the padding spaces
             local padding = 42
 
+            -- get width of console
+            local console_width = os.getwinsize()["width"]
+
             -- print tasks
             for taskname, taskinfo in pairs(categorytask) do
 
@@ -977,7 +1012,7 @@ function option.show_main()
 
                 -- append the task description
                 if taskinfo.description then
-                    taskline = taskline .. taskinfo.description
+                    taskline = inwidth_append(taskline, taskinfo.description, padding + 1 - 18, console_width, console_width - padding - 1 + 18)
                 end
 
                 -- print task line
@@ -1045,38 +1080,6 @@ function option.show_options(options)
 
         -- append color
         option_info = "${green}" .. option_info .. "${clear}"
-
-        function get_linelen(st)
-            local poss = string.find(string.reverse(st), "\n")
-            if not poss then return (#st) end
-            local start_pos, _ = poss
-            return start_pos - 1
-        end
-        function inwidth_append(dst, st, padding, width, remain_width)
-            function get_lastspace(st)
-                local poss = string.find(string.reverse(st), "[%s-]")
-                if not poss then return (#st) end
-                local start_pos, _ = poss
-                return (#st) - start_pos + 1
-            end
-            if padding >= width then
-                return dst .. st
-            end
-            local white_padding = string.rep(" ", padding)
-            if remain_width == nil then remain_width = width - get_linelen(dst) end    -- because of colored string, it's wrong sometimes
-            if remain_width <= 0 then
-                return inwidth_append(dst .. "\n" .. white_padding, st, padding, width, width - padding)
-            end
-            if (#st) <= remain_width then
-                return dst .. st
-            end
-            local lastspace = get_lastspace(string.sub(st, 1, remain_width))
-            if lastspace + 1 > (#st) then
-                return dst .. st
-            else
-                return inwidth_append(dst .. string.sub(st, 1, lastspace) .. "\n" .. white_padding, string.ltrim(string.sub(st, lastspace + 1)), padding, width, width - padding)
-            end
-        end
 
         -- get width of console
         local console_width = os.getwinsize()["width"]

--- a/xmake/core/project/task.lua
+++ b/xmake/core/project/task.lua
@@ -142,9 +142,9 @@ function task._translate_menu(menu)
         table.insert(options, 8, {'F', "file",      "kv", nil, "Read a given xmake.lua file."               })
         table.insert(options, 9, {'P', "project",   "kv", nil, "Change to the given project directory."
                                                               , "Search priority:"
-                                                              , "    1. The Given Command Argument"
-                                                              , "    2. The Envirnoment Variable: XMAKE_PROJECT_DIR"
-                                                              , "    3. The Current Directory"              })
+                                                              , "  1. The Given Command Argument"
+                                                              , "  2. The Envirnoment Variable: XMAKE_PROJECT_DIR"
+                                                              , "  3. The Current Directory"              })
         table.insert(options, 10, {})
 
     end


### PR DESCRIPTION
in standard 80x40 terminal, `xmake --help` print help info will overflow in horizontal which not looks nice

I add feature to get terminal size in runtime and soft-wrap the help printing

It has only tested on linux. If it's able to work in macos, please add the macos define check in `getwinsize.c` by directly push here