### PR TITLE
specify statsfile's path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - xmake -P core
   - export XMAKE_PROGRAM_DIR=$PWD/xmake
   - core/build/xmake lua versioninfo
-  - echo 'require("luacov")' > tmp
+  - echo "require('luacov.runner').init({['statsfile']='$PWD/luacov.stats.out',['reportfile']='$PWD/luacov.report.out'})" > tmp
   - cat xmake/core/_xmake_main.lua >> tmp
   - mv tmp xmake/core/_xmake_main.lua
   - cp core/build/xmake $(which xmake) || sudo cp core/build/xmake $(which xmake)


### PR DESCRIPTION
to avoid multi statsfile and not found

I found after ce27b8d coverage is decreased weirdly. That's because some `luacov.stats.out` are not found. I specified statsfile's path to make a single statsfile to be found