### PR TITLE
better root checking & process redirect fixing

### DIFF
--- a/core/src/xmake/machine.c
+++ b/core/src/xmake/machine.c
@@ -81,6 +81,9 @@ tb_int_t xm_os_emptydir(lua_State* lua);
 tb_int_t xm_os_strerror(lua_State* lua);
 tb_int_t xm_os_getwinsize(lua_State* lua);
 tb_int_t xm_os_versioninfo(lua_State* lua);
+#ifndef TB_CONFIG_OS_WINDOWS
+tb_int_t xm_os_uid(lua_State* lua);
+#endif
 
 // the path functions
 tb_int_t xm_path_relative(lua_State* lua);
@@ -141,6 +144,9 @@ static luaL_Reg const g_os_functions[] =
 ,   { "strerror",       xm_os_strerror  }
 ,   { "getwinsize",     xm_os_getwinsize}
 ,   { "versioninfo",    xm_os_versioninfo}
+#ifndef TB_CONFIG_OS_WINDOWS
+,   { "uid",            xm_os_uid       }
+#endif
 ,   { tb_null,          tb_null         }
 };
 

--- a/core/src/xmake/makefile
+++ b/core/src/xmake/makefile
@@ -37,6 +37,7 @@ xmake_C_FILES 			+= \
 						os/strerror \
 						os/getwinsize \
 						os/versioninfo \
+						os/uid \
 						path/relative \
 						path/absolute \
 						path/translate \

--- a/core/src/xmake/os/uid.c
+++ b/core/src/xmake/os/uid.c
@@ -1,0 +1,65 @@
+/*!The Make-like Build Utility based on Lua
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright (C) 2015 - 2017, TBOOX Open Source Group.
+ *
+ * @author      TitanSnow
+ * @file        uid.c
+ *
+ */
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * trace
+ */
+#define TB_TRACE_MODULE_NAME                "uid"
+#define TB_TRACE_MODULE_DEBUG               (0)
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * includes
+ */
+#include "prefix.h"
+#ifndef TB_CONFIG_OS_WINDOWS
+#   include <unistd.h>
+
+/* //////////////////////////////////////////////////////////////////////////////////////
+ * implementation
+ */
+
+// get uid & euid
+tb_int_t xm_os_uid(lua_State* lua)
+{
+    // check
+    tb_assert_and_check_return_val(lua, 0);
+
+    // get uid & euid
+    uid_t uid = getuid(), euid = geteuid();
+
+    // push
+    lua_newtable(lua);
+    lua_pushstring(lua, "uid");
+    lua_pushinteger(lua, uid);
+    lua_settable(lua, -3);
+    lua_pushstring(lua, "euid");
+    lua_pushinteger(lua, euid);
+    lua_settable(lua, -3);
+
+    // ok
+    return 1;
+}
+
+#endif

--- a/core/src/xmake/process/open.c
+++ b/core/src/xmake/process/open.c
@@ -59,11 +59,11 @@ tb_int_t xm_process_open(lua_State* lua)
     {
         // redirect stdout to file
         attr.outfile = outfile;
-        attr.outmode = TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | TB_FILE_MODE_APPEND;
+        attr.outmode = TB_FILE_MODE_WO | TB_FILE_MODE_TRUNC | TB_FILE_MODE_CREAT;
 
         // remove the outfile first
-        if (tb_file_info(outfile, tb_null))
-            tb_file_remove(outfile);
+        // if (tb_file_info(outfile, tb_null))
+        //     tb_file_remove(outfile);
     }
 
     // redirect stderr?
@@ -71,11 +71,11 @@ tb_int_t xm_process_open(lua_State* lua)
     {
         // redirect stderr to file
         attr.errfile = errfile;
-        attr.errmode = TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | TB_FILE_MODE_APPEND;
+        attr.errmode = TB_FILE_MODE_WO | TB_FILE_MODE_TRUNC | TB_FILE_MODE_CREAT;
 
         // remove the errfile first
-        if (tb_file_info(errfile, tb_null))
-            tb_file_remove(errfile);
+        // if (tb_file_info(errfile, tb_null))
+        //     tb_file_remove(errfile);
     }
 
     // init process

--- a/core/src/xmake/process/openv.c
+++ b/core/src/xmake/process/openv.c
@@ -101,11 +101,11 @@ tb_int_t xm_process_openv(lua_State* lua)
     {
         // redirect stdout to file
         attr.outfile = outfile;
-        attr.outmode = TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | TB_FILE_MODE_APPEND;
+        attr.outmode = TB_FILE_MODE_WO | TB_FILE_MODE_TRUNC | TB_FILE_MODE_CREAT;
 
         // remove the outfile first
-        if (tb_file_info(outfile, tb_null))
-            tb_file_remove(outfile);
+        // if (tb_file_info(outfile, tb_null))
+        //     tb_file_remove(outfile);
     }
 
     // redirect stderr?
@@ -113,11 +113,11 @@ tb_int_t xm_process_openv(lua_State* lua)
     {
         // redirect stderr to file
         attr.errfile = errfile;
-        attr.errmode = TB_FILE_MODE_RW | TB_FILE_MODE_CREAT | TB_FILE_MODE_APPEND;
+        attr.errmode = TB_FILE_MODE_WO | TB_FILE_MODE_TRUNC | TB_FILE_MODE_CREAT;
 
         // remove the errfile first
-        if (tb_file_info(errfile, tb_null))
-            tb_file_remove(errfile);
+        // if (tb_file_info(errfile, tb_null))
+        //     tb_file_remove(errfile);
     }
 
     // init process

--- a/xmake/core/base/os.lua
+++ b/xmake/core/base/os.lua
@@ -422,13 +422,10 @@ end
 -- get the temporary directory
 function os.tmpdir()
 
-    -- attempt get user name
-    os._USER = os._USER or os.getenv("USER")
-
     -- get a temporary directory for each user
     local tmpdir = os._tmpdir()
-    if os._USER and #os._USER > 0 then
-        tmpdir = path.join(tmpdir, ".xmake_" .. os._USER)
+    if os.uid then
+        tmpdir = path.join(tmpdir, ".xmake_" .. os.uid().euid)
     else
         tmpdir = path.join(tmpdir, ".xmake")
     end

--- a/xmake/core/base/os.lua
+++ b/xmake/core/base/os.lua
@@ -649,8 +649,7 @@ function os.isroot()
     if os.host() == "windows" then
         -- TODO
     else
-        local ok, code = os.iorun("id -u")
-        if ok and code and code:trim() == '0' then
+        if os.uid().euid == 0 then
             os._ISROOT = true
         end
     end

--- a/xmake/core/base/os.lua
+++ b/xmake/core/base/os.lua
@@ -627,11 +627,7 @@ end
 
 -- get the system null device
 function os.nuldev()
-    if os.isroot() then
-        return os.tmpfile()
-    else
-        return xmake._NULDEV
-    end
+    return xmake._NULDEV
 end
 
 -- check run command as root


### PR DESCRIPTION
I write `os.uid()` to get uid instead of `id -u`

I modified the open mode of `process.open()` & `process.openv()`. Seems that the redirection has been fixed by this