### PR TITLE
fix targetdir,objectdir not used in vsproject

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs200x_vcproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs200x_vcproj.lua
@@ -250,7 +250,7 @@ function _make_configurations(vcprojfile, vsinfo, target, vcprojdir)
         vcprojfile:enter("<Configuration")
             vcprojfile:print("Name=\"$(mode)|Win32\"")
 			vcprojfile:print("OutputDirectory=\"%s\"", path.relative(path.absolute(target:targetdir()), vcprojdir))
-			vcprojfile:print("IntermediateDirectory=\"%s\"",path.relative(path.absolute(target:objectdir()), vcprojdir))
+			vcprojfile:print("IntermediateDirectory=\"%s\"", path.relative(path.absolute(target:objectdir()), vcprojdir))
 			vcprojfile:print("ConfigurationType=\"%d\"", assert(configuration_types[target:get("kind")]))
             vcprojfile:print("CharacterSet=\"2\"") -- mbc: 2, wcs: 1
             vcprojfile:print(">")

--- a/xmake/plugins/project/vstudio/impl/vs200x_vcproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs200x_vcproj.lua
@@ -40,7 +40,7 @@ function _make_compflags(sourcefile, target, vcprojdir)
 
         -- replace -Idir or /Idir
         flag = flag:gsub("[%-|/]I(.*)", function (dir)
-                        dir = dir:trim()
+                        dir = path.translate(dir:trim())
                         if not path.is_absolute(dir) then
                             dir = path.relative(path.absolute(dir), vcprojdir)
                         end
@@ -49,7 +49,7 @@ function _make_compflags(sourcefile, target, vcprojdir)
 
         -- replace -Fdsymbol.pdb or /Fdsymbol.pdb
         flag = flag:gsub("[%-|/]Fd(.*)", function (dir)
-                        dir = dir:trim()
+                        dir = path.translate(dir:trim())
                         if not path.is_absolute(dir) then
                             dir = path.relative(path.absolute(dir), vcprojdir)
                         end
@@ -82,7 +82,7 @@ function _make_linkflags(target, vcprojdir)
 
         -- replace -libpath:dir or /libpath:dir
         flag = flag:gsub("[%-|/]libpath:(.*)", function (dir)
-                        dir = dir:trim()
+                        dir = path.translate(dir:trim())
                         if not path.is_absolute(dir) then
                             dir = path.relative(path.absolute(dir), vcprojdir)
                         end
@@ -91,7 +91,7 @@ function _make_linkflags(target, vcprojdir)
 
         -- replace -pdb:symbol.pdb or /pdb:symbol.pdb
         flag = flag:gsub("[%-|/]pdb:(.*)", function (dir)
-                        dir = dir:trim()
+                        dir = path.translate(dir:trim())
                         if not path.is_absolute(dir) then
                             dir = path.relative(path.absolute(dir), vcprojdir)
                         end
@@ -249,8 +249,8 @@ function _make_configurations(vcprojfile, vsinfo, target, vcprojdir)
         -- make configuration for the current mode
         vcprojfile:enter("<Configuration")
             vcprojfile:print("Name=\"$(mode)|Win32\"")
-			vcprojfile:print("OutputDirectory=\"%s\"", path.relative(path.absolute(config.get("buildir")), vcprojdir))
-			vcprojfile:print("IntermediateDirectory=\"%$(ConfigurationName)\"")
+			vcprojfile:print("OutputDirectory=\"%s\"", path.relative(path.absolute(target:targetdir()), vcprojdir))
+			vcprojfile:print("IntermediateDirectory=\"%s\"",path.relative(path.absolute(target:objectdir()), vcprojdir))
 			vcprojfile:print("ConfigurationType=\"%d\"", assert(configuration_types[target:get("kind")]))
             vcprojfile:print("CharacterSet=\"2\"") -- mbc: 2, wcs: 1
             vcprojfile:print(">")

--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -67,6 +67,12 @@ function _make_targetinfo(mode, arch, target)
 
     -- save sourcebatches
     targetinfo.sourcebatches = target:sourcebatches()
+    
+    -- save target dir
+    targetinfo.targetdir = target:targetdir()
+    
+    -- save object dir
+    targetinfo.objectdir = target:objectdir()
 
     -- save compiler flags
     targetinfo.compflags = {}

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -197,7 +197,7 @@ function _make_configurations(vcxprojfile, vsinfo, target, vcxprojdir)
     for _, targetinfo in ipairs(target.info) do
         vcxprojfile:enter("<PropertyGroup Condition=\"\'%$(Configuration)|%$(Platform)\'==\'%s|%s\'\">", targetinfo.mode, targetinfo.arch)
             vcxprojfile:print("<OutDir>%s\\</OutDir>", path.relative(path.absolute(targetinfo.targetdir), vcxprojdir))
-            vcxprojfile:print("<IntDir>%s\\</IntDir>", path.relative(path.absolute(targetinfo.objectdir),vcxprojdir))
+            vcxprojfile:print("<IntDir>%s\\</IntDir>", path.relative(path.absolute(targetinfo.objectdir), vcxprojdir))
             vcxprojfile:print("<TargetName>%s</TargetName>", path.basename(targetinfo.targetfile))
             vcxprojfile:print("<TargetExt>%s</TargetExt>", path.extension(targetinfo.targetfile))
 

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -197,7 +197,7 @@ function _make_configurations(vcxprojfile, vsinfo, target, vcxprojdir)
     for _, targetinfo in ipairs(target.info) do
         vcxprojfile:enter("<PropertyGroup Condition=\"\'%$(Configuration)|%$(Platform)\'==\'%s|%s\'\">", targetinfo.mode, targetinfo.arch)
             vcxprojfile:print("<OutDir>%s\\</OutDir>", path.relative(path.absolute(targetinfo.targetdir), vcxprojdir))
-            vcxprojfile:print("<IntDir>%s\\</IntDir>",path.relative(path.absolute(targetinfo.objectdir),vcxprojdir))
+            vcxprojfile:print("<IntDir>%s\\</IntDir>", path.relative(path.absolute(targetinfo.objectdir),vcxprojdir))
             vcxprojfile:print("<TargetName>%s</TargetName>", path.basename(targetinfo.targetfile))
             vcxprojfile:print("<TargetExt>%s</TargetExt>", path.extension(targetinfo.targetfile))
 

--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -36,7 +36,7 @@ function _make_compflags(sourcefile, targetinfo, vcxprojdir)
 
         -- -Idir or /Idir
         flag = flag:gsub("[%-|/]I(.*)", function (dir)
-                        dir = dir:trim()
+                        dir = path.translate(dir:trim())
                         if not path.is_absolute(dir) then
                             dir = path.relative(path.absolute(dir), vcxprojdir)
                         end
@@ -64,7 +64,7 @@ function _make_linkflags(targetinfo, vcxprojdir)
 
         -- replace -libpath:dir or /libpath:dir
         flag = flag:gsub("[%-|/]libpath:(.*)", function (dir)
-                        dir = dir:trim()
+                        dir = path.translate(dir:trim())
                         if not path.is_absolute(dir) then
                             dir = path.relative(path.absolute(dir), vcxprojdir)
                         end
@@ -196,11 +196,10 @@ function _make_configurations(vcxprojfile, vsinfo, target, vcxprojdir)
     -- make OutputDirectory and IntermediateDirectory
     for _, targetinfo in ipairs(target.info) do
         vcxprojfile:enter("<PropertyGroup Condition=\"\'%$(Configuration)|%$(Platform)\'==\'%s|%s\'\">", targetinfo.mode, targetinfo.arch)
-            vcxprojfile:print("<OutDir>%s\\</OutDir>", path.relative(path.absolute(config.get("buildir")), vcxprojdir))
-            vcxprojfile:print("<IntDir>%$(Configuration)\\</IntDir>")
+            vcxprojfile:print("<OutDir>%s\\</OutDir>", path.relative(path.absolute(targetinfo.targetdir), vcxprojdir))
+            vcxprojfile:print("<IntDir>%s\\</IntDir>",path.relative(path.absolute(targetinfo.objectdir),vcxprojdir))
             vcxprojfile:print("<TargetName>%s</TargetName>", path.basename(targetinfo.targetfile))
             vcxprojfile:print("<TargetExt>%s</TargetExt>", path.extension(targetinfo.targetfile))
-            vcxprojfile:print("<TargetPath>%s</TargetPath>", path.relative(path.absolute(targetinfo.targetfile), vcxprojdir))
 
             if target.kind == "binary" then
                 vcxprojfile:print("<LinkIncremental>true</LinkIncremental>")
@@ -355,12 +354,6 @@ function _make_common_item(vcxprojfile, vsinfo, target, targetinfo, vcxprojdir)
                 end
             end
             vcxprojfile:print("<GenerateDebugInformation>%s</GenerateDebugInformation>", tostring(debug))
-
-            -- make *.pdb file path
-            local symbolfile = targetinfo.symbolfile
-            if symbolfile then
-                vcxprojfile:print("<ProgramDatabaseFile>%s</ProgramDatabaseFile>", path.relative(path.absolute(symbolfile), vcxprojdir))
-            end
         end
 
         -- make SubSystem
@@ -371,8 +364,6 @@ function _make_common_item(vcxprojfile, vsinfo, target, targetinfo, vcxprojdir)
         -- make TargetMachine
         vcxprojfile:print("<TargetMachine>%s</TargetMachine>", ifelse(targetinfo.arch == "x64", "MachineX64", "MachineX86"))
 
-        -- make OutputFile
-        vcxprojfile:print("<OutputFile>%s</OutputFile>", path.relative(path.absolute(targetinfo.targetfile), vcxprojdir))
 
     vcxprojfile:leave("</%s>", linkerkinds[targetinfo.targetkind])
 
@@ -382,11 +373,6 @@ function _make_common_item(vcxprojfile, vsinfo, target, targetinfo, vcxprojdir)
         -- make source options
         _make_source_options(vcxprojfile, targetinfo.commonflags)
 
-        -- make *.pdb file path
-        local symbolfile = targetinfo.symbolfile
-        if symbolfile then
-            vcxprojfile:print("<ProgramDatabaseFile>%s</ProgramDatabaseFile>", path.relative(path.absolute(symbolfile), vcxprojdir))
-        end
 
         -- use c or c++ precompiled header
         local pcheader = target.pcxxheader or target.pcheader


### PR DESCRIPTION
1.vs的输出目录调整为和xmake脚本中的一致，使用target:targetdir
2.vs的临时obj目录调整为和xmake脚本中的一致，使用target:objectdir
3.vs输出文件（包括pdb、lib等）去除显式指定，调整为使用$(TargetDir)$(TargetName)命名（该设置不指定会自动设置，所以不用显式指定）。该修改同时修复了动态库输出lib与xmake中指定目录不一致的bug
4.生成vs项目中的链接库目录、包含文件目录进行路径标准化转换