### PR TITLE
vsporject add some configs

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -75,11 +75,15 @@ function _make_targetinfo(mode, arch, target)
     targetinfo.objectdir = target:objectdir()
 
     -- save compiler flags
+    local firstcompflags=nil
     targetinfo.compflags = {}
-    for _, sourcebatch in pairs(target:sourcebatches()) do
+    for sourcekind, sourcebatch in pairs(target:sourcebatches()) do
         if not sourcebatch.rulename then
             for _, sourcefile in ipairs(sourcebatch.sourcefiles) do
                 local compflags = compiler.compflags(sourcefile, {target = target})
+                if not firstcompflags and (sourcekind == "cc" or sourcekind == "cxx") then
+                    firstcompflags = compflags
+                end
                 targetinfo.compflags[sourcefile] = compflags
             end
         end
@@ -88,6 +92,19 @@ function _make_targetinfo(mode, arch, target)
     -- save linker flags
     local linkflags = linker.linkflags(target:get("kind"), target:sourcekinds(), {target = target})
     targetinfo.linkflags = linkflags
+
+    -- set default mfc
+    targetinfo.mfc = ifelse(target:values("mfc"), "Dynamic", nil)
+    -- set unicode and mfc
+    for _, flag in pairs(firstcompflags) do
+        if flag:find("-DUNICODE") then
+            targetinfo.unicode = true
+        elseif flag:find("[%-|/]MT") then
+            targetinfo.mfc = ifelse(targetinfo.mfc, "Static", false)
+        elseif flag:find("[%-|/]MD") then
+            targetinfo.mfc = ifelse(targetinfo.mfc, "Dynamic", false)
+        end
+    end
 
     -- ok
     return targetinfo


### PR DESCRIPTION
1.suport vsproject mfc mode
target(xxx)
    -- for make vsproject on mfcmode
    set_values("mfc",true)

    -- for unicode mode
    add_defines("UNICODE")

    -- use MT or MD switch RuntimeLibrary, (debug use MTd,MDd)
    add_cxflags("-MT")

2.subsystem switch support
target(xxx)
    -- change subsystem to windows, default console
    add_ldflags("/SUBSYSTEM:WINDOWS",{force=true})