### PR TITLE
add windows mfc rule

### DIFF
--- a/xmake/rules/winsdk/mfc/env/xmake.lua
+++ b/xmake/rules/winsdk/mfc/env/xmake.lua
@@ -22,8 +22,8 @@
 -- @file        xmake.lua
 --
 
--- define rule: mfc
-rule("win.sdk.mfc")
+-- define rule: mfc.env
+rule("win.sdk.mfc.env")
 
     -- FIXME: before load need check of vs's minverion, if defined
     --before_load(function (target)

--- a/xmake/rules/winsdk/mfc/env/xmake.lua
+++ b/xmake/rules/winsdk/mfc/env/xmake.lua
@@ -22,28 +22,9 @@
 -- @file        xmake.lua
 --
 
--- define rule: sharedcapp
-rule("win.sdk.mfc.shared_app")
+-- define rule: mfc
+rule("win.sdk.mfc")
 
-    -- add mfc base rule
-    add_deps("win.sdk.mfc")
-
-    -- after load
-    after_load(function (target)
-
-        -- apply mfc settings
-        import("mfc").mfc_shared_app(target)        
-    end)
-
--- define rule: staticapp
-rule("win.sdk.mfc.static_app")
-
-    -- add mfc base rule
-    add_deps("win.sdk.mfc")
-
-    -- after load
-    after_load(function (target)
-
-        -- apply mfc settings
-        import("mfc").mfc_static_app(target)
-    end)
+    -- FIXME: before load need check of vs's minverion, if defined
+    --before_load(function (target)
+    --end)

--- a/xmake/rules/winsdk/mfc/mfc.lua
+++ b/xmake/rules/winsdk/mfc/mfc.lua
@@ -25,10 +25,10 @@
 -- remove exists md or mt
 function _mfc_remove_mt_md_flags(target, flagsname)
     local flags = table.wrap(target:get(flagsname))
-    for key, flag in pairs(flags) do
-        flag = flag:lower():trim()
+    for i = #flags, 1, -1 do
+        flag = flags[i]:lower():trim()
         if flag:find("^[/%-]?mt[d]?$") or flag:find("^[/%-]?md[d]?$") then
-            flags[key] = nil
+            table.remove(flags, i)
         end
     end
     target:set(flagsname, flags)
@@ -37,10 +37,10 @@ end
 -- remove exists settings
 function _mfc_remove_flags(target)
     local ldflags = table.wrap(target:get("ldflags"))
-    for key, ldflag in pairs(ldflags) do
-        ldflag = ldflag:lower():trim()
+    for i = #ldflags, 1, -1 do
+        ldflag = ldflags[i]:lower():trim()
         if ldflag:find("[/%-]subsystem:") then
-            ldflags[key] = nil
+            table.remove(ldflags, i)
             break
         end
     end
@@ -48,10 +48,10 @@ function _mfc_remove_flags(target)
     
     -- remove defines MT MTd MD MDd
     local defines = table.wrap(target:get("defines"))
-    for key, define in pairs(defines) do
-        define = define:lower():trim()
+    for i = #defines, 1, -1 do
+        define = defines[i]:lower():trim()
         if define:find("^[/%-]?mt[d]?$") or define:find("^[/%-]?md[d]?$") then
-            defines[key] = nil
+            table.remove(defines, i)
         end
     end
     target:set("defines", defines)

--- a/xmake/rules/winsdk/mfc/mfc.lua
+++ b/xmake/rules/winsdk/mfc/mfc.lua
@@ -25,17 +25,10 @@
 -- remove exists md or mt
 function _mfc_remove_mt_md_flags(target, flagsname)
     local flags = target:get(flagsname)
-    if type(flags) == "table" then
-        for key, flag in pairs(flags) do
-            flag = flag:lower():trim()
-            if flag:find("^[/%-]?mt[d]?$") or flag:find("^[/%-]?md[d]?$") then
-                flags[key] = nil
-            end
-        end
-    elseif type(flags) == "string" then
-        local flag = flags:lower()
-        if flag:find("[/%-]mt") or flag:find("[/%-]md") then
-            flags = {}
+    for key, flag in pairs(table.wrap(flags)) do
+        flag = flag:lower():trim()
+        if flag:find("^[/%-]?mt[d]?$") or flag:find("^[/%-]?md[d]?$") then
+            flags[key] = nil
         end
     end
     target:set(flagsname, flags)
@@ -44,14 +37,10 @@ end
 -- remove exists settings
 function _mfc_remove_flags(target)
     local ldflags = target:get("ldflags")
-    for key, ldflag in pairs(ldflags) do
+    for key, ldflag in pairs(table.wrap(ldflags)) do
         ldflag = ldflag:lower():trim()
         if ldflag:find("[/%-]subsystem:") then
-            if type(ldflags) == "table" then
-                ldflags[key] = nil
-            else
-                ldflags = {}
-            end
+            ldflags[key] = nil
             break
         end
     end
@@ -59,14 +48,10 @@ function _mfc_remove_flags(target)
     
     -- remove defines MT MTd MD MDd
     local defines = target:get("defines")
-    for key, define in pairs(defines) do
+    for key, define in pairs(table.wrap(defines)) do
         define = define:lower():trim()
         if define:find("^[/%-]?mt[d]?$") or define:find("^[/%-]?md[d]?$") then
-            if type(defines) == "table" then
-                defines[key] = nil
-            else
-                defines = {}
-            end
+            defines[key] = nil
         end
     end
     target:set("defines", defines)

--- a/xmake/rules/winsdk/mfc/mfc.lua
+++ b/xmake/rules/winsdk/mfc/mfc.lua
@@ -18,7 +18,7 @@
 -- 
 -- Copyright (C) 2015 - 2018, TBOOX Open Source Group.
 --
--- @author      ruki
+-- @author      xigal
 -- @file        xmake.lua
 --
 

--- a/xmake/rules/winsdk/mfc/mfc.lua
+++ b/xmake/rules/winsdk/mfc/mfc.lua
@@ -73,20 +73,20 @@ function _mfc_remove_flags(target)
     _mfc_remove_mt_md_flags(target, "cxxflags")
 end
 
--- check unicode
-function _mfc_check_is_unicode(target)
+-- get application entry
+function mfc_application_entry(target)
     local defines = target:get("defines")
     for key, define in pairs(defines) do
         define = define:lower()
         if define:find("unicode") or define:find("_unicode") then
-            return true
+            return "-entry:wWinMainCRTStartup"
         end
     end
-    return false
+    return "-entry:WinMainCRTStartup"
 end
 
 -- apply shared mfc settings
-function _mfc_shared(target)
+function mfc_shared(target)
 
     -- remove some exists flags
     _mfc_remove_flags(target)
@@ -100,7 +100,7 @@ function _mfc_shared(target)
 end
 
 -- apply static mfc settings
-function _mfc_static(target)
+function mfc_static(target)
 
     -- remove some exists flags
     _mfc_remove_flags(target)
@@ -111,30 +111,4 @@ function _mfc_static(target)
 
     -- set runtimelibrary
     target:add("cxflags", ifelse(is_mode("debug"), "-MTd", "-MT"))
-end
-
--- apply appliction settings use static mfc
-function mfc_static_app(target)
-
-    -- static common
-    _mfc_static(target)
-
-    -- set kind: binary
-    target:set("kind", "binary")
-
-    -- set entry
-    target:add("ldflags", ifelse(_mfc_check_is_unicode(target), "-entry:wWinMainCRTStartup", "-entry:WinMainCRTStartup"), {force = true})
-end
-
--- apply appliction settings use shared mfc
-function mfc_shared_app(target)
-
-    -- static common
-    _mfc_shared(target)
-
-    -- set kind: binary
-    target:set("kind", "binary")
-
-    -- set entry
-    target:add("ldflags", ifelse(_mfc_check_is_unicode(target), "-entry:wWinMainCRTStartup", "-entry:WinMainCRTStartup"), {force = true})
 end

--- a/xmake/rules/winsdk/mfc/mfc.lua
+++ b/xmake/rules/winsdk/mfc/mfc.lua
@@ -27,8 +27,8 @@ function _mfc_remove_mt_md_flags(target, flagsname)
     local flags = target:get(flagsname)
     if type(flags) == "table" then
         for key, flag in pairs(flags) do
-            flag = flag:lower()
-            if flag:find("[/%-]mt") or flag:find("[/%-]md") then
+            flag = flag:lower():trim()
+            if flag:find("^[/%-]?mt[d]?$") or flag:find("^[/%-]?md[d]?$") then
                 flags[key] = nil
             end
         end
@@ -45,20 +45,28 @@ end
 function _mfc_remove_flags(target)
     local ldflags = target:get("ldflags")
     for key, ldflag in pairs(ldflags) do
-        ldflag = ldflag:lower()
+        ldflag = ldflag:lower():trim()
         if ldflag:find("[/%-]subsystem:") then
-            ldflags[key] = nil
+            if type(ldflags) == "table" then
+                ldflags[key] = nil
+            else
+                ldflags = {}
+            end
             break
         end
     end
     target:set("ldflags", ldflags)
     
-    -- remove defines /DMT /DMTd /DMD /DMDd
+    -- remove defines MT MTd MD MDd
     local defines = target:get("defines")
     for key, define in pairs(defines) do
-        define = define:lower()
-        if define:find("[/%-]dmt") or define:find("[/%-]dmd") then
-            defines[key] = nil
+        define = define:lower():trim()
+        if define:find("^[/%-]?mt[d]?$") or define:find("^[/%-]?md[d]?$") then
+            if type(defines) == "table" then
+                defines[key] = nil
+            else
+                defines = {}
+            end
         end
     end
     target:set("defines", defines)
@@ -77,8 +85,8 @@ end
 function mfc_application_entry(target)
     local defines = target:get("defines")
     for key, define in pairs(defines) do
-        define = define:lower()
-        if define:find("unicode") or define:find("_unicode") then
+        define = define:lower():trim()
+        if define:find("^[_]?unicode$") then
             return "-entry:wWinMainCRTStartup"
         end
     end

--- a/xmake/rules/winsdk/mfc/mfc.lua
+++ b/xmake/rules/winsdk/mfc/mfc.lua
@@ -24,8 +24,8 @@
 
 -- remove exists md or mt
 function _mfc_remove_mt_md_flags(target, flagsname)
-    local flags = target:get(flagsname)
-    for key, flag in pairs(table.wrap(flags)) do
+    local flags = table.wrap(target:get(flagsname))
+    for key, flag in pairs(flags) do
         flag = flag:lower():trim()
         if flag:find("^[/%-]?mt[d]?$") or flag:find("^[/%-]?md[d]?$") then
             flags[key] = nil
@@ -36,8 +36,8 @@ end
 
 -- remove exists settings
 function _mfc_remove_flags(target)
-    local ldflags = target:get("ldflags")
-    for key, ldflag in pairs(table.wrap(ldflags)) do
+    local ldflags = table.wrap(target:get("ldflags"))
+    for key, ldflag in pairs(ldflags) do
         ldflag = ldflag:lower():trim()
         if ldflag:find("[/%-]subsystem:") then
             ldflags[key] = nil
@@ -47,8 +47,8 @@ function _mfc_remove_flags(target)
     target:set("ldflags", ldflags)
     
     -- remove defines MT MTd MD MDd
-    local defines = target:get("defines")
-    for key, define in pairs(table.wrap(defines)) do
+    local defines = table.wrap(target:get("defines"))
+    for key, define in pairs(defines) do
         define = define:lower():trim()
         if define:find("^[/%-]?mt[d]?$") or define:find("^[/%-]?md[d]?$") then
             defines[key] = nil

--- a/xmake/rules/winsdk/mfc/mfc.lua
+++ b/xmake/rules/winsdk/mfc/mfc.lua
@@ -1,0 +1,140 @@
+--!A cross-platform build utility based on Lua
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+-- 
+-- Copyright (C) 2015 - 2018, TBOOX Open Source Group.
+--
+-- @author      ruki
+-- @file        xmake.lua
+--
+
+-- remove exists md or mt
+function _mfc_remove_mt_md_flags(target, flagsname)
+    local flags = target:get(flagsname)
+    if type(flags) == "table" then
+        for key, flag in pairs(flags) do
+            flag = flag:lower()
+            if flag:find("[/%-]mt") or flag:find("[/%-]md") then
+                flags[key] = nil
+            end
+        end
+    elseif type(flags) == "string" then
+        local flag = flags:lower()
+        if flag:find("[/%-]mt") or flag:find("[/%-]md") then
+            flags = {}
+        end
+    end
+    target:set(flagsname, flags)
+end
+
+-- remove exists settings
+function _mfc_remove_flags(target)
+    local ldflags = target:get("ldflags")
+    for key, ldflag in pairs(ldflags) do
+        ldflag = ldflag:lower()
+        if ldflag:find("[/%-]subsystem:") then
+            ldflags[key] = nil
+            break
+        end
+    end
+    target:set("ldflags", ldflags)
+    
+    -- remove defines /DMT /DMTd /DMD /DMDd
+    local defines = target:get("defines")
+    for key, define in pairs(defines) do
+        define = define:lower()
+        if define:find("[/%-]dmt") or define:find("[/%-]dmd") then
+            defines[key] = nil
+        end
+    end
+    target:set("defines", defines)
+    
+    -- remove c /MD,/MT
+    _mfc_remove_mt_md_flags(target, "cflags")
+    
+    -- remove c,cpp /MD,/MT
+    _mfc_remove_mt_md_flags(target, "cxflags")
+    
+    -- remove cpp /MD,/MT
+    _mfc_remove_mt_md_flags(target, "cxxflags")
+end
+
+-- check unicode
+function _mfc_check_is_unicode(target)
+    local defines = target:get("defines")
+    for key, define in pairs(defines) do
+        define = define:lower()
+        if define:find("unicode") or define:find("_unicode") then
+            return true
+        end
+    end
+    return false
+end
+
+-- apply shared mfc settings
+function _mfc_shared(target)
+
+    -- remove some exists flags
+    _mfc_remove_flags(target)
+
+    -- add flags
+    target:add("ldflags", "-subsystem:windows", {force = true})
+
+    -- set runtimelibrary
+    target:add("cxflags", ifelse(is_mode("debug"), "-MDd", "-MD"))
+    target:add("defines", "AFX", "_AFXDLL")
+end
+
+-- apply static mfc settings
+function _mfc_static(target)
+
+    -- remove some exists flags
+    _mfc_remove_flags(target)
+
+    -- add flags
+    target:add("ldflags", "-subsystem:windows", {force = true})
+    target:add("ldflags", "-force", {force = true})
+
+    -- set runtimelibrary
+    target:add("cxflags", ifelse(is_mode("debug"), "-MTd", "-MT"))
+end
+
+-- apply appliction settings use static mfc
+function mfc_static_app(target)
+
+    -- static common
+    _mfc_static(target)
+
+    -- set kind: binary
+    target:set("kind", "binary")
+
+    -- set entry
+    target:add("ldflags", ifelse(_mfc_check_is_unicode(target), "-entry:wWinMainCRTStartup", "-entry:WinMainCRTStartup"), {force = true})
+end
+
+-- apply appliction settings use shared mfc
+function mfc_shared_app(target)
+
+    -- static common
+    _mfc_shared(target)
+
+    -- set kind: binary
+    target:set("kind", "binary")
+
+    -- set entry
+    target:add("ldflags", ifelse(_mfc_check_is_unicode(target), "-entry:wWinMainCRTStartup", "-entry:WinMainCRTStartup"), {force = true})
+end

--- a/xmake/rules/winsdk/mfc/xmake.lua
+++ b/xmake/rules/winsdk/mfc/xmake.lua
@@ -26,7 +26,7 @@
 rule("win.sdk.mfc.shared")
 
     -- add mfc base rule
-    add_deps("win.sdk.mfc")
+    add_deps("win.sdk.mfc.env")
 
     -- after load
     after_load(function (target)
@@ -39,7 +39,7 @@ rule("win.sdk.mfc.shared")
 rule("win.sdk.mfc.static")
 
     -- add mfc base rule
-    add_deps("win.sdk.mfc")
+    add_deps("win.sdk.mfc.env")
 
     -- after load
     after_load(function (target)

--- a/xmake/rules/winsdk/mfc/xmake.lua
+++ b/xmake/rules/winsdk/mfc/xmake.lua
@@ -22,8 +22,8 @@
 -- @file        xmake.lua
 --
 
--- define rule: sharedcapp
-rule("win.sdk.mfc.shared_app")
+-- define rule: shared
+rule("win.sdk.mfc.shared")
 
     -- add mfc base rule
     add_deps("win.sdk.mfc")
@@ -32,18 +32,50 @@ rule("win.sdk.mfc.shared_app")
     after_load(function (target)
 
         -- apply mfc settings
-        import("mfc").mfc_shared_app(target)        
+        import("mfc").mfc_shared(target)
+    end)
+
+-- define rule: static
+rule("win.sdk.mfc.static")
+
+    -- add mfc base rule
+    add_deps("win.sdk.mfc")
+
+    -- after load
+    after_load(function (target)
+
+        -- apply mfc settings
+        import("mfc").mfc_static(target)
+    end)
+
+-- define rule: sharedcapp
+rule("win.sdk.mfc.shared_app")
+
+    -- add mfc base rule
+    add_deps("win.sdk.mfc.shared")
+
+    -- after load
+    after_load(function (target)
+
+        -- set kind: binary
+        target:set("kind", "binary")
+
+        -- set entry
+        target:add("ldflags", import("mfc").mfc_application_entry(target), {force = true})       
     end)
 
 -- define rule: staticapp
 rule("win.sdk.mfc.static_app")
 
     -- add mfc base rule
-    add_deps("win.sdk.mfc")
+    add_deps("win.sdk.mfc.static")
 
     -- after load
     after_load(function (target)
 
-        -- apply mfc settings
-        import("mfc").mfc_static_app(target)
+        -- set kind: binary
+        target:set("kind", "binary")
+
+        -- set entry
+        target:add("ldflags", import("mfc").mfc_application_entry(target), {force = true})
     end)

--- a/xmake/rules/winsdk/mfc/xmake.lua
+++ b/xmake/rules/winsdk/mfc/xmake.lua
@@ -22,33 +22,30 @@
 -- @file        xmake.lua
 --
 
--- define rule: application
-rule("win.sdk.application")
+-- define rule: shared mfcapp
+rule("win.sdk.mfcapp.shared")
 
-    -- add deps
-    add_deps("win.sdk.dotnet")
+    -- FIXME: before load need check of vs's minverion, if defined
+    --before_load(function (target)
+    --end)
 
     -- after load
     after_load(function (target)
 
-        -- set kind: binary
-        target:set("kind", "binary")
+        -- apply mfc settings
+        import("mfc").mfc_shared_app(target)        
+    end)
 
-        -- set subsystem: windows
-        local subsystem = false
-        for _, ldflag in ipairs(target:get("ldflags")) do
-            ldflag = ldflag:lower()
-            if ldflag:find("[/%-]subsystem:") then
-                subsystem = true
-                break
-            end
-        end
-        if not subsystem then
-            target:add("ldflags", "-subsystem:windows", {force = true})
-        end
+-- define rule: static mfcapp
+rule("win.sdk.mfcapp.static")
 
-        -- add links
-        target:add("links", "kernel32", "user32", "gdi32", "winspool", "comdlg32", "advapi32")
-        target:add("links", "shell32", "ole32", "oleaut32", "uuid", "odbc32", "odbccp32", "comctl32")
-        target:add("links", "cfgmgr32", "comdlg32", "setupapi", "strsafe", "shlwapi")
+    -- FIXME: before load need check of vs's minverion, if defined
+    --before_load(function (target)
+    --end)
+
+    -- after load
+    after_load(function (target)
+
+        -- apply mfc settings
+        import("mfc").mfc_static_app(target)
     end)

--- a/xmake/rules/winsdk/xmake.lua
+++ b/xmake/rules/winsdk/xmake.lua
@@ -22,6 +22,69 @@
 -- @file        xmake.lua
 --
 
+-- remove exists md or mt
+function _rule_remove_mt_md_flags(target, flagsname)
+    local flags = target:get(flagsname)
+    if type(flags) == "table" then
+        for key, flag in pairs(flags) do
+            flag = flag:lower()
+            if flag:find("[/%-]mt") or flag:find("[/%-]md") then
+                flags[key] = nil
+            end
+        end
+    elseif type(flags) == "string" then
+        local flag = flags:lower()
+        if flag:find("[/%-]mt") or flag:find("[/%-]md") then
+            flags = {}
+        end
+    end
+    target:set(flagsname, flags)
+end
+
+-- remove exists settings
+function _rule_remove_exists_flags(target)
+    local ldflags = target:get("ldflags")
+    for key, ldflag in pairs(ldflags) do
+        ldflag = ldflag:lower()
+        if ldflag:find("[/%-]subsystem:") then
+            ldflags[key] = nil
+            break
+        end
+    end
+    target:set("ldflags", ldflags)
+    
+    -- remove defines /DMT /DMTd /DMD /DMDd
+    local defines = target:get("defines")
+    for key, define in pairs(defines) do
+        define = define:lower()
+        if define:find("[/%-]dmt") or define:find("[/%-]dmd") then
+            defines[key] = nil
+        end
+    end
+    target:set("defines", defines)
+    
+    -- remove c /MD,/MT
+    _rule_remove_mt_md_flags(target, "cflags")
+    
+    -- remove c,cpp /MD,/MT
+    _rule_remove_mt_md_flags(target, "cxflags")
+    
+    -- remove cpp /MD,/MT
+    _rule_remove_mt_md_flags(target, "cxxflags")
+end
+
+-- check unicode
+function _rule_check_is_unicode(target)
+    local defines = target:get("defines")
+    for key, define in pairs(defines) do
+        define = define:lower()
+        if define:find("unicode") or define:find("_unicode") then
+            return true
+        end
+    end
+    return false
+end
+
 -- define rule: application
 rule("win.sdk.application")
 
@@ -51,5 +114,62 @@ rule("win.sdk.application")
         target:add("links", "kernel32", "user32", "gdi32", "winspool", "comdlg32", "advapi32")
         target:add("links", "shell32", "ole32", "oleaut32", "uuid", "odbc32", "odbccp32", "comctl32")
         target:add("links", "cfgmgr32", "comdlg32", "setupapi", "strsafe", "shlwapi")
+    end)
+
+-- define rule: sharedmfcapp
+rule("win.sdk.mfcapp.shared")
+
+    -- save local functions
+    local remove_exists_flags = _rule_remove_exists_flags
+    local check_is_unicode = _rule_check_is_unicode
+
+    -- after load
+    after_load(function (target)
+
+        -- set kind: binary
+        target:set("kind", "binary")
+
+        -- remove some exists flags
+        remove_exists_flags(target)
+
+        -- add flags
+        target:add("ldflags", "-subsystem:windows", {force = true})
+        target:add("ldflags", ifelse(check_is_unicode(target), "-entry:wWinMainCRTStartup", "-entry:WinMainCRTStartup"), {force = true})
+
+        -- set runtimelibrary
+        target:add("cxflags", ifelse(is_mode("debug"), "-MDd", "-MD"))
+        target:add("defines", "AFX", "_AFXDLL")
+
+        -- add mfc flags
+        target:values_set("project.vs.mfc", true)
+    end)
+
+
+-- define rule: staticmfcapp
+rule("win.sdk.mfcapp.static")
+
+    -- save local functions
+    local remove_exists_flags = _rule_remove_exists_flags
+    local check_is_unicode = _rule_check_is_unicode
+
+    -- after load
+    after_load(function (target)
+
+        -- set kind: binary
+        target:set("kind", "binary")
+
+        -- remove some exists flags
+        remove_exists_flags(target)
+
+        -- add flags
+        target:add("ldflags", "-subsystem:windows", {force = true})
+        target:add("ldflags", "-force", {force = true})
+        target:add("ldflags", ifelse(check_is_unicode(target), "-entry:wWinMainCRTStartup", "-entry:WinMainCRTStartup"), {force = true})
+
+        -- set runtimelibrary
+        target:add("cxflags", ifelse(is_mode("debug"), "-MTd", "-MT"))
+
+        -- add mfc flags
+        target:values_set("project.vs.mfc", true)
     end)
 


### PR DESCRIPTION
usage:

```lua
target("test")
    add_files("*.cpp")
    add_files("*.rc")
    -- use sharedmfc
    add_rules("win.sdk.mfc.shared_app")
    -- or add_rules("win.sdk.mfc.static_app") to use staticmfc
target_end()
```