### PR TITLE
fix detection strategy for MSVC/VS2017+

### DIFF
--- a/xmake/modules/detect/tools/find_vswhere.lua
+++ b/xmake/modules/detect/tools/find_vswhere.lua
@@ -51,7 +51,9 @@ function main(opt)
     opt = opt or {}
     
     -- find program
-    opt.pathes = opt.pathes or 
+    opt.check   = "-?"
+    opt.command = "-?"
+    opt.pathes = opt.pathes or
     {
         path.join(os.getenv("ProgramFiles(x86)"), "Microsoft Visual Studio", "Installer", "vswhere.exe"),
         path.join(os.getenv("ProgramFiles"), "Microsoft Visual Studio", "Installer", "vswhere.exe"),


### PR DESCRIPTION
fix detection strategy for MSVC/VS2017+

* fixes the MSVC/VS 2017 detection problem discussed within <https://github.com/tboox/xmake/issues/225>

### Discussion

MSVC/VS versions >= 15.0 will no longer be setting registry entries for tool location purposes. But `vswhere` (included with MSVC/VS versions >= 15.2, and placed in a guaranteed location) can instead be used to find the needed path.

`os.runv(...)` is used as the tool to gather `vswhere` output instead of `($shell ...)` in order to avoid some `($shell ...)` limitations. Commands containing white space and/or special characters (eg, '[', ')') are difficult or impossible to pass through the current `($shell ...)` implementation, causing application exceptions. Both white space and the noted special characters are needed to construct the required `vswhere` command.

ref: <https://github.com/Microsoft/vswhere/blob/master/README.md> @@ <https://archive.is/mEmdu>