### PR TITLE
revise progress formatting to space-leading three digit percentages

### DIFF
--- a/xmake/actions/build/kinds/binary.lua
+++ b/xmake/actions/build/kinds/binary.lua
@@ -77,7 +77,7 @@ function _build_from_objects(target, buildinfo)
     local verbose = option.get("verbose")
 
     -- trace progress into
-    cprintf("${green}[%02d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
+    cprintf("${green}[%3d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
     if verbose then
         cprint("${dim magenta}linking.$(mode) %s", path.filename(targetfile))
     else
@@ -111,7 +111,7 @@ function _build_from_sources(target, buildinfo, sourcebatch, sourcekind)
     local verbose = option.get("verbose")
 
     -- trace progress into
-    cprintf("${green}[%02d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
+    cprintf("${green}[%3d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
     if verbose then
         cprint("${dim magenta}linking.$(mode) %s", path.filename(targetfile))
     else

--- a/xmake/actions/build/kinds/object.lua
+++ b/xmake/actions/build/kinds/object.lua
@@ -41,9 +41,9 @@ function _build_from_object(target, sourcefile, objectfile, progress)
 
     -- trace progress info
     if verbose then
-        cprint("${green}[%02d%%]: ${dim magenta}inserting.$(mode) %s", progress, sourcefile)
+        cprint("${green}[%3d%%]: ${dim magenta}inserting.$(mode) %s", progress, sourcefile)
     else
-        cprint("${green}[%02d%%]: ${magenta}inserting.$(mode) %s", progress, sourcefile)
+        cprint("${green}[%3d%%]: ${magenta}inserting.$(mode) %s", progress, sourcefile)
     end
 
     -- trace verbose info
@@ -66,9 +66,9 @@ function _build_from_static(target, sourcefile, objectfile, progress)
 
     -- trace progress info
     if verbose then
-        cprint("${green}[%02d%%]: ${dim magenta}inserting.$(mode) %s", progress, sourcefile)
+        cprint("${green}[%3d%%]: ${dim magenta}inserting.$(mode) %s", progress, sourcefile)
     else
-        cprint("${green}[%02d%%]: ${magenta}inserting.$(mode) %s", progress, sourcefile)
+        cprint("${green}[%3d%%]: ${magenta}inserting.$(mode) %s", progress, sourcefile)
     end
 
     -- trace verbose info
@@ -123,9 +123,9 @@ function _build_object(target, buildinfo, index, sourcebatch, ccache)
 
     -- trace progress info
     if verbose then
-        cprint("${green}[%02d%%]:${dim} %scompiling.$(mode) %s", progress, ifelse(ccache, "ccache ", ""), sourcefile)
+        cprint("${green}[%3d%%]:${dim} %scompiling.$(mode) %s", progress, ifelse(ccache, "ccache ", ""), sourcefile)
     else
-        cprint("${green}[%02d%%]:${clear} %scompiling.$(mode) %s", progress, ifelse(ccache, "ccache ", ""), sourcefile)
+        cprint("${green}[%3d%%]:${clear} %scompiling.$(mode) %s", progress, ifelse(ccache, "ccache ", ""), sourcefile)
     end
 
     -- trace verbose info
@@ -184,9 +184,9 @@ function _build_single_object(target, buildinfo, sourcekind, sourcebatch, jobs, 
 
         -- trace progress info
         if verbose then
-            cprint("${green}[%02d%%]:${clear} ${dim}%scompiling.$(mode) %s", progress, ifelse(ccache, "ccache ", ""), sourcefile)
+            cprint("${green}[%3d%%]:${clear} ${dim}%scompiling.$(mode) %s", progress, ifelse(ccache, "ccache ", ""), sourcefile)
         else
-            cprint("${green}[%02d%%]:${clear} %scompiling.$(mode) %s", progress, ifelse(ccache, "ccache ", ""), sourcefile)
+            cprint("${green}[%3d%%]:${clear} %scompiling.$(mode) %s", progress, ifelse(ccache, "ccache ", ""), sourcefile)
         end
     end
 

--- a/xmake/actions/build/kinds/shared.lua
+++ b/xmake/actions/build/kinds/shared.lua
@@ -90,7 +90,7 @@ function _build_from_objects(target, buildinfo)
     local verbose = option.get("verbose")
 
     -- trace progress info
-    cprintf("${green}[%02d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
+    cprintf("${green}[%3d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
     if verbose then
         cprint("${dim magenta}linking.$(mode) %s", path.filename(targetfile))
     else
@@ -124,7 +124,7 @@ function _build_from_sources(target, buildinfo, sourcebatch, sourcekind)
     local verbose = option.get("verbose")
 
     -- trace progress into
-    cprintf("${green}[%02d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
+    cprintf("${green}[%3d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
     if verbose then
         cprint("${dim magenta}linking.$(mode) %s", path.filename(targetfile))
     else

--- a/xmake/actions/build/kinds/static.lua
+++ b/xmake/actions/build/kinds/static.lua
@@ -86,7 +86,7 @@ function _build_from_objects(target, buildinfo)
     local verbose = option.get("verbose")
 
     -- trace progress info
-    cprintf("${green}[%02d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
+    cprintf("${green}[%3d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
     if verbose then
         cprint("${dim magenta}archiving.$(mode) %s", path.filename(targetfile))
     else
@@ -120,7 +120,7 @@ function _build_from_sources(target, buildinfo, sourcebatch, sourcekind)
     local verbose = option.get("verbose")
 
     -- trace progress into
-    cprintf("${green}[%02d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
+    cprintf("${green}[%3d%%]:${clear} ", (buildinfo.targetindex + 1) * 100 / buildinfo.targetcount)
     if verbose then
         cprint("${dim magenta}archiving.$(mode) %s", path.filename(targetfile))
     else

--- a/xmake/rules/qt/moc/xmake.lua
+++ b/xmake/rules/qt/moc/xmake.lua
@@ -82,9 +82,9 @@ rule("qt.moc")
 
         -- trace progress info
         if option.get("verbose") then
-            cprint("${green}[%02d%%]:${dim} compiling.qt.moc %s", opt.progress, headerfile_moc)
+            cprint("${green}[%3d%%]:${dim} compiling.qt.moc %s", opt.progress, headerfile_moc)
         else
-            cprint("${green}[%02d%%]:${clear} compiling.qt.moc %s", opt.progress, headerfile_moc)
+            cprint("${green}[%3d%%]:${clear} compiling.qt.moc %s", opt.progress, headerfile_moc)
         end
 
         -- generate c++ source file for moc

--- a/xmake/rules/qt/qrc/xmake.lua
+++ b/xmake/rules/qt/qrc/xmake.lua
@@ -85,9 +85,9 @@ rule("qt.qrc")
 
         -- trace progress info
         if option.get("verbose") then
-            cprint("${green}[%02d%%]:${dim} compiling.qt.qrc %s", opt.progress, sourcefile_qrc)
+            cprint("${green}[%3d%%]:${dim} compiling.qt.qrc %s", opt.progress, sourcefile_qrc)
         else
-            cprint("${green}[%02d%%]:${clear} compiling.qt.qrc %s", opt.progress, sourcefile_qrc)
+            cprint("${green}[%3d%%]:${clear} compiling.qt.qrc %s", opt.progress, sourcefile_qrc)
         end
 
         -- ensure the source file directory

--- a/xmake/rules/qt/ui/xmake.lua
+++ b/xmake/rules/qt/ui/xmake.lua
@@ -72,9 +72,9 @@ rule("qt.ui")
 
         -- trace progress info
         if option.get("verbose") then
-            cprint("${green}[%02d%%]:${dim} compiling.qt.ui %s", opt.progress, sourcefile_ui)
+            cprint("${green}[%3d%%]:${dim} compiling.qt.ui %s", opt.progress, sourcefile_ui)
         else
-            cprint("${green}[%02d%%]:${clear} compiling.qt.ui %s", opt.progress, sourcefile_ui)
+            cprint("${green}[%3d%%]:${clear} compiling.qt.ui %s", opt.progress, sourcefile_ui)
         end
 
         -- ensure ui header file directory

--- a/xmake/rules/wdk/inf/xmake.lua
+++ b/xmake/rules/wdk/inf/xmake.lua
@@ -95,9 +95,9 @@ rule("wdk.inf")
 
         -- trace progress info
         if option.get("verbose") then
-            cprint("${green}[%02d%%]:${dim} compiling.wdk.inf %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${dim} compiling.wdk.inf %s", opt.progress, sourcefile)
         else
-            cprint("${green}[%02d%%]:${clear} compiling.wdk.inf %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${clear} compiling.wdk.inf %s", opt.progress, sourcefile)
         end
 
         -- get stampinf

--- a/xmake/rules/wdk/man/xmake.lua
+++ b/xmake/rules/wdk/man/xmake.lua
@@ -125,9 +125,9 @@ rule("wdk.man")
 
         -- trace progress info
         if option.get("verbose") then
-            cprint("${green}[%02d%%]:${dim} compiling.wdk.man %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${dim} compiling.wdk.man %s", opt.progress, sourcefile)
         else
-            cprint("${green}[%02d%%]:${clear} compiling.wdk.man %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${clear} compiling.wdk.man %s", opt.progress, sourcefile)
         end
 
         -- generate header and resource file

--- a/xmake/rules/wdk/mc/xmake.lua
+++ b/xmake/rules/wdk/mc/xmake.lua
@@ -105,9 +105,9 @@ rule("wdk.mc")
 
         -- trace progress info
         if option.get("verbose") then
-            cprint("${green}[%02d%%]:${dim} compiling.wdk.mc %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${dim} compiling.wdk.mc %s", opt.progress, sourcefile)
         else
-            cprint("${green}[%02d%%]:${clear} compiling.wdk.mc %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${clear} compiling.wdk.mc %s", opt.progress, sourcefile)
         end
 
         -- do message compile

--- a/xmake/rules/wdk/mof/xmake.lua
+++ b/xmake/rules/wdk/mof/xmake.lua
@@ -115,9 +115,9 @@ rule("wdk.mof")
 
         -- trace progress info
         if option.get("verbose") then
-            cprint("${green}[%02d%%]:${dim} compiling.wdk.mof %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${dim} compiling.wdk.mof %s", opt.progress, sourcefile)
         else
-            cprint("${green}[%02d%%]:${clear} compiling.wdk.mof %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${clear} compiling.wdk.mof %s", opt.progress, sourcefile)
         end
 
         -- ensure the output directory

--- a/xmake/rules/wdk/sign/xmake.lua
+++ b/xmake/rules/wdk/sign/xmake.lua
@@ -115,7 +115,7 @@ rule("wdk.sign")
         target:data_add("wdk.cleanfiles", {tempfile, dependfile})
 
         -- trace progress info
-        cprintf("${green}[%02d%%]:${clear} ", opt.progress)
+        cprintf("${green}[%3d%%]:${clear} ", opt.progress)
         if option.get("verbose") then
             cprint("${dim magenta}signing.%s %s", signmode, path.filename(target:targetfile()))
         else

--- a/xmake/rules/wdk/tracewpp/xmake.lua
+++ b/xmake/rules/wdk/tracewpp/xmake.lua
@@ -103,9 +103,9 @@ rule("wdk.tracewpp")
 
         -- trace progress info
         if option.get("verbose") then
-            cprint("${green}[%02d%%]:${dim} compiling.wdk.tracewpp %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${dim} compiling.wdk.tracewpp %s", opt.progress, sourcefile)
         else
-            cprint("${green}[%02d%%]:${clear} compiling.wdk.tracewpp %s", opt.progress, sourcefile)
+            cprint("${green}[%3d%%]:${clear} compiling.wdk.tracewpp %s", opt.progress, sourcefile)
         end
 
         -- ensure the output directory


### PR DESCRIPTION
Formatting was a bit off for progress when hitting 100%. I thought the leading zeros were also distracting. I can put those back in if you prefer them. It's just not what I'm used to seeing.

### before

```shell
C:>rm -r build .xmake & xmake
checking for the architecture ... x64
checking for the Microsoft Visual Studio (x64) version ... 2015
building to: build\windows.release.cl.x64\bin\hello.exe
[00%]: compiling.release src\main.rc
[50%]: compiling.release src\main.c
[100%]: linking.release hello.exe
```

### after

```shell
C:>rm -r build .xmake & xmake
checking for the architecture ... x64
checking for the Microsoft Visual Studio (x64) version ... 2015
building to: build\windows.release.cl.x64\bin\hello.exe
[  0%]: compiling.release src\main.rc
[ 50%]: compiling.release src\main.c
[100%]: linking.release hello.exe
```

There was no single location for the change, so I changed it throughout the code base. I thought about localizing it to a single code location, but I wasn't sure where it would be best placed. Future localization would probably be a good idea though in order to plan for alternative formatting (different color choices, etc).

