### PR TITLE
Fixes a issues that failed to run vcvarsall when vs_toolset and vs_sdkver are setted at same time.

### DIFF
--- a/xmake/modules/detect/sdks/find_vstudio.lua
+++ b/xmake/modules/detect/sdks/find_vstudio.lua
@@ -253,8 +253,8 @@ function main(opt)
         if vcvarsall then
 
             -- load vcvarsall
-            local vcvarsall_x86 = _load_vcvarsall(vcvarsall, "x86", opt.vcvars_ver)
-            local vcvarsall_x64 = _load_vcvarsall(vcvarsall, "x64", opt.vcvars_ver)
+            local vcvarsall_x86 = _load_vcvarsall(vcvarsall, "x86", opt.vcvars_ver, opt.sdkver)
+            local vcvarsall_x64 = _load_vcvarsall(vcvarsall, "x64", opt.vcvars_ver, opt.sdkver)
 
             -- save results
             results[vsvers[version]] = {version = version, vcvarsall_bat = vcvarsall, vcvarsall = {x86 = vcvarsall_x86, x64 = vcvarsall_x64}}


### PR DESCRIPTION
執行 xmake config 的時候只要同時使用 `--vs_toolset=14.0` 和 `--vs_sdkver=10.0.10586.0` 就無法正確用 find_vstudio 找到編譯資訊。

我修改了find_vstudio 的內容，印出一些執行期間log

``` lua
--------------------------------------------------------------------------------
In function (main)   <in pairs(vsvers)>:  version = 4.2
--------------------------------------------------------------------------------
In function (main)   <in pairs(vsvers)>:  version = 7.1
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 12.0
In function (main):  vcvars_ver = 14.0
In function (main):  sdkver = 10.0.10586.0
In function (_load_vcvarsall):  vcvars_ver = 14.0
In function (_load_vcvarsall):  <kv> path = C:\xmake\bin;
In function (_load_vcvarsall):  <kv> lib =
In function (_load_vcvarsall):  <kv> libpath =
In function (_load_vcvarsall):  <kv> include =
In function (_load_vcvarsall):  <kv> DevEnvdir =
In function (_load_vcvarsall):  <kv> VSInstallDir =
In function (_load_vcvarsall):  <kv> VCInstallDir =
In function (_load_vcvarsall):  <kv> WindowsSdkDir =
In function (_load_vcvarsall):  <kv> WindowsLibPath =
In function (_load_vcvarsall):  <kv> WindowsSDKVersion =
In function (_load_vcvarsall):  <kv> WindowsSdkBinPath =
In function (_load_vcvarsall):  <kv> UniversalCRTSdkDir =
In function (_load_vcvarsall):  <kv> UCRTVersion =
In function (_load_vcvarsall):  vcvars_ver = 14.0
In function (_load_vcvarsall):  <kv> path = C:\xmake\bin;
In function (_load_vcvarsall):  <kv> lib =
In function (_load_vcvarsall):  <kv> libpath =
In function (_load_vcvarsall):  <kv> include =
In function (_load_vcvarsall):  <kv> DevEnvdir =
In function (_load_vcvarsall):  <kv> VSInstallDir =
In function (_load_vcvarsall):  <kv> VCInstallDir =
In function (_load_vcvarsall):  <kv> WindowsSdkDir =
In function (_load_vcvarsall):  <kv> WindowsLibPath =
In function (_load_vcvarsall):  <kv> WindowsSDKVersion =
In function (_load_vcvarsall):  <kv> WindowsSdkBinPath =
In function (_load_vcvarsall):  <kv> UniversalCRTSdkDir =
In function (_load_vcvarsall):  <kv> UCRTVersion =
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 15.0
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 6.0
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 7.0
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 8.0
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 9.0
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 14.0
In function (main):  vcvars_ver = 14.0
In function (main):  sdkver = 10.0.10586.0
In function (_load_vcvarsall):  vcvars_ver = 14.0
In function (_load_vcvarsall):  <kv> path = C:\xmake\bin;
In function (_load_vcvarsall):  <kv> lib =
In function (_load_vcvarsall):  <kv> libpath =
In function (_load_vcvarsall):  <kv> include =
In function (_load_vcvarsall):  <kv> DevEnvdir =
In function (_load_vcvarsall):  <kv> VSInstallDir =
In function (_load_vcvarsall):  <kv> VCInstallDir =
In function (_load_vcvarsall):  <kv> WindowsSdkDir =
In function (_load_vcvarsall):  <kv> WindowsLibPath =
In function (_load_vcvarsall):  <kv> WindowsSDKVersion =
In function (_load_vcvarsall):  <kv> WindowsSdkBinPath =
In function (_load_vcvarsall):  <kv> UniversalCRTSdkDir =
In function (_load_vcvarsall):  <kv> UCRTVersion =
In function (_load_vcvarsall):  vcvars_ver = 14.0
In function (_load_vcvarsall):  <kv> path = C:\xmake\bin;
In function (_load_vcvarsall):  <kv> lib =
In function (_load_vcvarsall):  <kv> libpath =
In function (_load_vcvarsall):  <kv> include =
In function (_load_vcvarsall):  <kv> DevEnvdir =
In function (_load_vcvarsall):  <kv> VSInstallDir =
In function (_load_vcvarsall):  <kv> VCInstallDir =
In function (_load_vcvarsall):  <kv> WindowsSdkDir =
In function (_load_vcvarsall):  <kv> WindowsLibPath =
In function (_load_vcvarsall):  <kv> WindowsSDKVersion =
In function (_load_vcvarsall):  <kv> WindowsSdkBinPath =
In function (_load_vcvarsall):  <kv> UniversalCRTSdkDir =
In function (_load_vcvarsall):  <kv> UCRTVersion =
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 11.0
In function (main):  vcvars_ver = 14.0
In function (main):  sdkver = 10.0.10586.0
In function (_load_vcvarsall):  vcvars_ver = 14.0
In function (_load_vcvarsall):  <kv> path = C:\xmake\bin;
In function (_load_vcvarsall):  <kv> lib =
In function (_load_vcvarsall):  <kv> libpath =
In function (_load_vcvarsall):  <kv> include =
In function (_load_vcvarsall):  <kv> DevEnvdir =
In function (_load_vcvarsall):  <kv> VSInstallDir =
In function (_load_vcvarsall):  <kv> VCInstallDir =
In function (_load_vcvarsall):  <kv> WindowsSdkDir =
In function (_load_vcvarsall):  <kv> WindowsLibPath =
In function (_load_vcvarsall):  <kv> WindowsSDKVersion =
In function (_load_vcvarsall):  <kv> WindowsSdkBinPath =
In function (_load_vcvarsall):  <kv> UniversalCRTSdkDir =
In function (_load_vcvarsall):  <kv> UCRTVersion =
In function (_load_vcvarsall):  vcvars_ver = 14.0
In function (_load_vcvarsall):  <kv> path = C:\xmake\bin;
In function (_load_vcvarsall):  <kv> lib =
In function (_load_vcvarsall):  <kv> libpath =
In function (_load_vcvarsall):  <kv> include =
In function (_load_vcvarsall):  <kv> DevEnvdir =
In function (_load_vcvarsall):  <kv> VSInstallDir =
In function (_load_vcvarsall):  <kv> VCInstallDir =
In function (_load_vcvarsall):  <kv> WindowsSdkDir =
In function (_load_vcvarsall):  <kv> WindowsLibPath =
In function (_load_vcvarsall):  <kv> WindowsSDKVersion =
In function (_load_vcvarsall):  <kv> WindowsSdkBinPath =
In function (_load_vcvarsall):  <kv> UniversalCRTSdkDir =
In function (_load_vcvarsall):  <kv> UCRTVersion =
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 10.0
--------------------------------------------------------------------------------
In function (main):  <in pairs(vsvers)>:  version = 5.0
===== dump table <results>

{
    2012 =
    {
        vcvarsall_bat = C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\Tools\..\..\VC\vcvarsall.bat
    ,   version = 11.0
    ,   vcvarsall =
        {
            x86 =
            {
                path = C:\xmake\bin;
            }

        ,   x64 =
            {
                path = C:\xmake\bin;
            }

        }

    }

,   2013 =
    {
        vcvarsall_bat = C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat
    ,   version = 12.0
    ,   vcvarsall =
        {
            x86 =
            {
                path = C:\xmake\bin;
            }

        ,   x64 =
            {
                path = C:\xmake\bin;
            }

        }

    }

,   2015 =
    {
        vcvarsall_bat = C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
    ,   version = 14.0
    ,   vcvarsall =
        {
            x86 =
            {
                path = C:\xmake\bin;
            }

        ,   x64 =
            {
                path = C:\xmake\bin;
            }

        }

    }

}

===== end
checking for the Microsoft Visual Studio (x64) version ... no
please run:
    - xmake config --vs=xxx [--vs_toolset=xxx]
or  - xmake global --vs=xxx
```