### PR TITLE
avoids warning LNK4010 when subsystem version is different then 5.01

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -53,7 +53,7 @@ function _get_toolset_ver(targetinfo, vsinfo)
 
     -- for xp?
     for _, flag in ipairs(targetinfo.linkflags) do
-        if flag:lower():find("[%-/]subsystem:.-,5.01$") then
+        if flag:lower():find("^[%-/]subsystem:.-,5%.%d+$") then
             toolset_ver = toolset_ver .. "_xp"
             break
         end


### PR DESCRIPTION
在目前預設的行為之下，如果 `add_ldflags("/subsystem:console,5.01")` 產生出來的vc2015 project 編譯期間會有警告，發生原因貌似是因為Minimum Required Version被自動填入5.02了。
```
LINK : warning LNK4010: invalid subsystem version number 5.01; default subsystem version assumed
```

但是如果改為  `add_ldflags("/subsystem:console,5.02") 卻會發生Platform Toolset沒有被正確設定為v140_xp的問題。