### PR TITLE
improves the arch setting

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x.lua
@@ -163,6 +163,38 @@ function _make_targetheaders(mode, arch, target, last)
     end
 end
 
+function _make_vsinfo_modes()
+    local vsinfo_modes = {}
+    local modes = option.get("modes")
+    if modes then
+        for _, mode in ipairs(modes:split(',')) do
+            table.insert(vsinfo_modes, mode:trim())
+        end
+    else
+        vsinfo_modes = project.modes()
+    end
+    if not vsinfo_modes or #vsinfo_modes == 0 then
+        vsinfo_modes = { config.mode() }
+    end
+    return vsinfo_modes
+end
+
+function _make_vsinfo_archs()
+    local vsinfo_archs = {}
+    local archs = option.get("archs")
+    if archs then
+        for _, arch in ipairs(archs:split(',')) do
+            table.insert(vsinfo_archs, arch:trim())
+        end
+    else
+        vsinfo_archs = platform.archs()
+    end
+    if not vsinfo_archs or #vsinfo_archs == 0 then
+        vsinfo_archs = { config.arch() }
+    end
+    return vsinfo_archs
+end
+
 -- make vstudio project
 function make(outputdir, vsinfo)
 
@@ -173,23 +205,15 @@ function make(outputdir, vsinfo)
     vsinfo.solution_dir = path.join(outputdir, "vs" .. vsinfo.vstudio_version)
 
     -- init modes
-    local modes = option.get("modes")
-    if modes then
-        vsinfo.modes = {}
-        for _, mode in ipairs(modes:split(',')) do
-            table.insert(vsinfo.modes, mode:trim())
-        end
-    else
-        vsinfo.modes = project.modes()
-    end
-    if not vsinfo.modes or #vsinfo.modes == 0 then
-        vsinfo.modes = { config.mode() }
-    end
+    vsinfo.modes = _make_vsinfo_modes()
+    
+    -- init archs
+    vsinfo.archs = _make_vsinfo_archs()
 
     -- load targets
     local targets = {}
     for mode_idx, mode in ipairs(vsinfo.modes) do
-        for arch_idx, arch in ipairs({"x86", "x64"}) do
+        for arch_idx, arch in ipairs(vsinfo.archs) do
 
             -- trace
             print("checking for the %s.%s ...", mode, arch)

--- a/xmake/plugins/project/vstudio/impl/vs201x_solution.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_solution.lua
@@ -67,7 +67,7 @@ function _make_global(slnfile, vsinfo)
     -- add solution configuration platforms
     slnfile:enter("GlobalSection(SolutionConfigurationPlatforms) = preSolution")
     for _, mode in ipairs(vsinfo.modes) do
-        for _, arch in ipairs({"x86", "x64"}) do
+        for _, arch in ipairs(vsinfo.archs) do
             slnfile:print("%s|%s = %s|%s", mode, arch, mode, arch)
         end
     end
@@ -78,7 +78,7 @@ function _make_global(slnfile, vsinfo)
     for targetname, target in pairs(project.targets()) do
         if not target:isphony() then
             for _, mode in ipairs(vsinfo.modes) do
-                for _, arch in ipairs({"x86", "x64"}) do
+                for _, arch in ipairs(vsinfo.archs) do
                     slnfile:print("{%s}.%s|%s.ActiveCfg = %s|%s", hash.uuid(targetname), mode, arch, mode, arch)
                     slnfile:print("{%s}.%s|%s.Build.0 = %s|%s", hash.uuid(targetname), mode, arch, mode, arch)
                 end

--- a/xmake/plugins/project/xmake.lua
+++ b/xmake/plugins/project/xmake.lua
@@ -51,6 +51,9 @@ task("project")
                                                        ,    "    - xmake project -k makefile"
                                                        ,    "    - xmake project -k compile_commands"
                                                        ,    "    - xmake project -k vs2015 -m \"release,debug\"" }
+                ,   {'a', "archs",     "kv", nil,           "Set the project archs." 
+                                                       ,    "    .e.g "
+                                                       ,    "    - xmake project -k vs2015 -a \"x86,x64\"" }
                 ,   {nil, "outputdir", "v",  ".",           "Set the output directory." }
                 }
             }


### PR DESCRIPTION
* 主要是想讓 arch 可以如同 mode 一樣的有彈性。因為VS其實支持更多種類的 `<Platform>XXXXX</Platform>` 。對於一些平台的開發，其實會需要不同於 Win32/x64 的選項，所以認為這邊可以不需要寫成固定的判斷。
* 預設的狀況下，xmake project 依舊可以一次產生出全部的 modes / archs 設置。
* 在有自定義需求下，設置-a 或 --archs 可以僅產生指定的設置。
* arch 內容不再寫死 ，可以是 arm / ORBIS/ 之類的字串...  增加未來擴充的可能
