### PR TITLE
improves project plugin, and preprocessor definitions could be correctly setted now.

### DIFF
--- a/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
+++ b/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua
@@ -288,6 +288,18 @@ function _make_source_options(vcxprojfile, flags, condition)
     if flagstr:find("[%-/]WX") then
         vcxprojfile:print("<TreatWarningAsError%s>true</TreatWarningAsError>", condition) 
     end
+    
+    -- make PreprocessorDefinitions
+    local defstr = ""
+    for _, flag in ipairs(flags) do
+        flag:gsub("[%-/]D(.*)",
+            function (def) 
+                defstr = defstr .. def .. ";"
+            end
+        )
+    end
+    defstr = defstr .. "%%(PreprocessorDefinitions)"
+    vcxprojfile:print("<PreprocessorDefinitions%s>%s</PreprocessorDefinitions>", condition, defstr) 
 
     -- make DebugInformationFormat
     if flagstr:find("[%-/]Zi") then
@@ -329,7 +341,7 @@ function _make_source_options(vcxprojfile, flags, condition)
 
     -- make AdditionalOptions
     local additional_flags = {}
-    local excludes = {"Os", "O0", "O1", "O2", "Ot", "Ox", "W0", "W1", "W2", "W3", "WX", "Wall", "Zi", "ZI", "Z7", "MT", "MTd", "MD", "MDd", "TP", "Fd", "fp", "I"}
+    local excludes = {"Od", "Os", "O0", "O1", "O2", "Ot", "Ox", "W0", "W1", "W2", "W3", "WX", "Wall", "Zi", "ZI", "Z7", "MT", "MTd", "MD", "MDd", "TP", "Fd", "fp", "I", "D"}
     for _, flag in ipairs(flags) do
         local excluded = false
         for _, exclude in ipairs(excludes) do


### PR DESCRIPTION
根據實測VS2013、VS2015、VS2017，我只需要簡單修改vcxproj的一些設置就可以支援 ORBIS和DURANGO
```
<Platform>ORBIS</Platform>
<PlatformToolset>Clang</PlatformToolset>
然後再添加很少的額外標籤，就可以完整使用VS支援該平台。
```
但是在試驗過程中發現，因為官方預設會安裝一些VS擴展工具，而某些工具會需要讀取到PreprocessorDefinitions才能方便使用，所以這裡提交了一個小修改。
- 維持現在的macro設置，僅僅只是移動到VS的設置內
- 移除 additional_flags 中多餘的 -Od 選項，因為必定存在 [< Optimization >Disabled< / Optimization >](https://github.com/tboox/xmake/blob/dev/xmake/plugins/project/vstudio/impl/vs201x_vcxproj.lua#L264)