### PR TITLE
improve abi include directory for ndk

### DIFF
--- a/xmake/platforms/android/load.lua
+++ b/xmake/platforms/android/load.lua
@@ -184,13 +184,13 @@ function main(platform)
                 
                 -- include abi directory
                 if cxxstl_sdkdir:find("llvm-libc++", 1, true) then
-                    local abi_path = path.translate(format("%s/sources/cxx-stl/llvm-libc++abi", ndk))
-                    local before_r13 = path.translate(path.join(abi_path, "libcxxabi"))
-                    local after_r13 = path.translate(path.join(abi_path, "include"))
+                    local abi_path = path.join(ndk, "sources", "cxx-stl", "llvm-libc++abi")
+                    local before_r13 = path.join(abi_path, "libcxxabi")
+                    local after_r13 = path.join(abi_path, "include")
                     if os.isdir(before_r13) then
-                        platform:add("cxxflags", format("-I%s",before_r13))
+                        platform:add("cxxflags", "-I" .. before_r13)
                     elseif os.isdir(after_r13) then
-                        platform:add("cxxflags", format("-I%s",after_r13))
+                        platform:add("cxxflags", "-I" .. after_r13)
                     end
                 end
             end

--- a/xmake/platforms/android/load.lua
+++ b/xmake/platforms/android/load.lua
@@ -172,12 +172,26 @@ function main(platform)
                 platform:add("cxxflags", format("-I%s/libs/%s/include", cxxstl_sdkdir, toolchains_archs[arch]))
                 platform:add("ldflags", format("-L%s/libs/%s", cxxstl_sdkdir, toolchains_archs[arch]))
                 platform:add("shflags", format("-L%s/libs/%s", cxxstl_sdkdir, toolchains_archs[arch]))
+                
+                -- link to c++ std library
                 if cxxstl_sdkdir:find("llvm-libc++", 1, true) then
                     platform:add("ldflags", "-lc++_static", "-lc++abi")
                     platform:add("shflags", "-lc++_static", "-lc++abi")
                 else
                     platform:add("ldflags", "-lgnustl_static")
                     platform:add("shflags", "-lgnustl_static")
+                end
+                
+                -- include abi directory
+                if cxxstl_sdkdir:find("llvm-libc++", 1, true) then
+                    local abi_path = path.translate(format("%s/sources/cxx-stl/llvm-libc++abi", ndk))
+                    local before_r13 = path.translate(path.join(abi_path, "libcxxabi"))
+                    local after_r13 = path.translate(path.join(abi_path, "include"))
+                    if os.isdir(before_r13) then
+                        platform:add("cxxflags", format("-I%s",before_r13))
+                    elseif os.isdir(after_r13) then
+                        platform:add("cxxflags", format("-I%s",after_r13))
+                    end
                 end
             end
         end


### PR DESCRIPTION
使用 xmake + NDK 編譯 googletest 的過程中發現錯誤 `fatal error: 'cxxabi.h' file not found` 
驗證了一下，添加 `cxx-stl/llvm-libc++abi/include` 後可以解決並正常運行。
這個 PR 修改的include 部分有檢測 r13b 前後的兩種版本，實測後都可使用。